### PR TITLE
 Tighten up the language in help texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ is stored in `$HOME/.kusari/tokens.json`.
 
 Scans a diff on a git repository using [Kusari
 Inspector](https://www.kusari.dev/inspector). This will scan a set of changes,
-so a "git diff" command is needed. Usage:
+so a "git diff" path is needed. Usage:
 
 ```
-kusari repo scan <directory> <git-diff command>
+kusari repo scan <directory> <git-diff path>
 ```
 
 Where `<directory>` is the directory of the git repository you wish to scan,
-and `<git-diff command>` is the command to pass to `git diff` to generate the
+and `<git-diff path>` is the path to pass to `git diff` to generate the
 set of changes. See [Git
 documentation](https://git-scm.com/docs/git-diff#_examples), for examples of
 commands.

--- a/kusari/cmd/repo_scan.go
+++ b/kusari/cmd/repo_scan.go
@@ -34,9 +34,9 @@ func scan() *cobra.Command {
 
 var scancmd = &cobra.Command{
 	Use:   "scan <directory> <git-diff command>",
-	Short: "Package directory and diff, then submit for analysis",
-	Long: `Run a git-diff command against a repository, then package the directory and diff. Submit for diff analysis in Kusar Inspector.
-    <directory>        Should be a Git directory of code to be analyzed
-    <git-diff command> Should be the arguments to provide to git-diff to determine what diff to analyze`,
+	Short: "Scan a git diff with Kusari Inspector",
+	Long: `Run a git-diff command against a repository, then submit the directory and diff for analysis in Kusai Inspector.
+    <directory>        A directory containing a git repository to analyze
+    <git-diff path> Git paths to analyze, using git-difff arguments`,
 	Args: cobra.MinimumNArgs(2),
 }

--- a/kusari/cmd/root.go
+++ b/kusari/cmd/root.go
@@ -19,8 +19,8 @@ func init() {
 
 var rootCmd = &cobra.Command{
 	Use:   "kusari",
-	Short: "Kusari - All signal, no noise. No chasing. No surprises. Just secure code, faster.",
-	Long:  "Kusari - All signal, no noise. No chasing. No surprises. Just secure code, faster.",
+	Short: "Kusari CLI",
+	Long:  "Kusari CLI - Interact with Kusari products",
 }
 
 func Execute() error {


### PR DESCRIPTION
I don't entirely love replacing "git-diff command" with "git-diff path", but I know I don't like "command" because it implies a full command as opposed to the path (which is what the git documentation uses) plus options.