### PR TITLE
Use https instead of http

### DIFF
--- a/kusari/cmd/root.go
+++ b/kusari/cmd/root.go
@@ -13,7 +13,7 @@ var (
 )
 
 func init() {
-	rootCmd.PersistentFlags().StringVarP(&consoleUrl, "console-url", "", "http://console.us.kusari.cloud/", "console url")
+	rootCmd.PersistentFlags().StringVarP(&consoleUrl, "console-url", "", "https://console.us.kusari.cloud/", "console url")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
 }
 


### PR DESCRIPTION
It doesn't actually matter, since the server forces https, but it looks better for a security-related project to say https from the beginning.