### PR TITLE
Add a flag to wait for output

### DIFF
--- a/kusari/cmd/repo_scan.go
+++ b/kusari/cmd/repo_scan.go
@@ -12,10 +12,12 @@ import (
 
 var (
 	platformUrl string
+	wait        bool
 )
 
 func init() {
 	scancmd.Flags().StringVarP(&platformUrl, "platform-url", "", "https://platform.api.us.kusari.cloud/", "platform url")
+	scancmd.Flags().BoolVarP(&wait, "wait", "w", true, "wait for results")
 }
 
 func scan() *cobra.Command {
@@ -36,7 +38,7 @@ func scan() *cobra.Command {
 			return fmt.Errorf("no git diff command provided")
 		}
 
-		return repo.Scan(dir, diff, platformUrl, consoleUrl, verbose)
+		return repo.Scan(dir, diff, platformUrl, consoleUrl, verbose, wait)
 	}
 
 	return scancmd

--- a/pkg/repo/scanner.go
+++ b/pkg/repo/scanner.go
@@ -28,7 +28,7 @@ const (
 	tarballDir  = "kusari-dir"
 )
 
-func Scan(dir string, diffCmd []string, platformUrl string, consoleUrl string, verbose bool) error {
+func Scan(dir string, diffCmd []string, platformUrl string, consoleUrl string, verbose bool, wait bool) error {
 	if verbose {
 		fmt.Fprintf(os.Stderr, " dir: %s\n", dir)
 		fmt.Fprintf(os.Stderr, " diffCmd: %s\n", strings.Join(diffCmd, " "))
@@ -109,7 +109,13 @@ func Scan(dir string, diffCmd []string, platformUrl string, consoleUrl string, v
 	// We print the URL when it is completed, but that doesn't help if it fails
 	// for some reason and the user needs to contact support.
 	fmt.Fprintf(os.Stderr, "Once completed, you can see results at: %s\n", *consoleFullUrl)
-	return queryForResult(platformUrl, epoch, token.AccessToken, consoleFullUrl)
+
+	// Wait for results if the user wants, or exit immediately
+	if wait {
+		return queryForResult(platformUrl, epoch, token.AccessToken, consoleFullUrl)
+	} else {
+		return nil
+	}
 }
 
 func queryForResult(platformUrl string, epoch *string, accessToken string, consoleFullUrl *string) error {


### PR DESCRIPTION
Default to true to keep existing behavior, but support people who don't want to wait.

Fixes #47