### PR TITLE
Restrict the git diff command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,36 +19,34 @@ is stored in `$HOME/.kusari/tokens.json`.
 
 Scans a diff on a git repository using [Kusari
 Inspector](https://www.kusari.dev/inspector). This will scan a set of changes,
-so a "git diff" path is needed. Usage:
+so a git revision is needed to compare to. Usage:
 
 ```
-kusari repo scan <directory> <git-diff path>
+kusari repo scan <directory> <git-rev>
 ```
 
 Where `<directory>` is the directory of the git repository you wish to scan,
-and `<git-diff path>` is the path to pass to `git diff` to generate the
-set of changes. See [Git
-documentation](https://git-scm.com/docs/git-diff#_examples), for examples of
-commands.
-
-* __Note:__ The current working tree must be the end state of the diff. Create a diff from some other branch or commit to the current working tree.
+and `<git-rev>` is the git revision to compare with the working tree to
+generate the set of changes. See [Git
+documentation](https://git-scm.com/docs/gitrevisions), for examples of git
+revisions. The revision must be a single revision to compare the working tree
+against, not a range.
 
 Examples:
 
 ```
 kusari repo scan ~/git/guac HEAD^
-kusari repo scan ~/git/guac main
 ```
 
-**For git diff arguments that start with `--` (like `--cached`, `--staged`), use the `--` separator:**
+Will scan my `~/git/guac` repository and compare the working tree with the
+commit before the most recent commit.
 
 ```
-kusari repo scan ~/git/guac -- --cached
-kusari repo scan ~/git/guac -- --staged --name-only
+kusari repo scan ~/git/guac origin/main
 ```
 
-Will scan my `~/git/guac` repository with the git-diff command `HEAD^` which
-compares my working tree with the commit before the most recent commit.
+Will scan my `~/git/guac` repository and compare the working tree with the
+`main` branch from the remote `origin`.
 
 Kusari Inspector results will be stored and displayed in the [Kusari
 Console](https://console.us.kusari.cloud/analysis/cli).

--- a/kusari/cmd/repo_scan.go
+++ b/kusari/cmd/repo_scan.go
@@ -4,8 +4,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/kusaridev/kusari-cli/pkg/repo"
 	"github.com/spf13/cobra"
 )
@@ -23,37 +21,19 @@ func init() {
 func scan() *cobra.Command {
 	scancmd.RunE = func(cmd *cobra.Command, args []string) error {
 		dir := args[0]
-		var diff []string
+		ref := args[1]
 
-		// Handle the -- separator case
-		if len(args) >= 3 && args[1] == "--" {
-			diff = args[2:]
-		} else if len(args) >= 2 {
-			diff = args[1:]
-		} else {
-			return fmt.Errorf("not enough arguments")
-		}
-
-		if len(diff) == 0 {
-			return fmt.Errorf("no git diff command provided")
-		}
-
-		return repo.Scan(dir, diff, platformUrl, consoleUrl, verbose, wait)
+		return repo.Scan(dir, ref, platformUrl, consoleUrl, verbose, wait)
 	}
 
 	return scancmd
 }
 
 var scancmd = &cobra.Command{
-	Use:   "scan <directory> <git-diff command>",
-	Short: "Scan a git diff with Kusari Inspector",
-	Long: `Run a git-diff command against a repository, then submit the directory and diff for analysis in Kusari Inspector.
-    <directory>     	A directory containing a git repository to analyze
-    <git-diff path> 	Git paths to analyze, using git-diff arguments
-
-Use the separator "--" to pass git diff arguments that start with "--":
-    kusari repo scan /path/to/repo -- --cached
-    kusari repo scan /path/to/repo -- --staged --name-only
-    kusari repo scan /path/to/repo -- HEAD^`,
-	Args: cobra.MinimumNArgs(2),
+	Use:   "scan <directory> <git-rev>",
+	Short: "Scan a change with Kusari Inspector",
+	Long: `Generate a change set against a repository, then submit the directory and diff for analysis in Kusari Inspector.
+    <directory>  A directory containing a git repository to analyze
+    <git-rev>    Git revision to compare to the working tree`,
+	Args: cobra.ExactArgs(2),
 }

--- a/pkg/repo/packager.go
+++ b/pkg/repo/packager.go
@@ -34,7 +34,7 @@ func packageDirectory() error {
 	return nil
 }
 
-func createMeta(diffCmd []string) error {
+func createMeta(rev string) error {
 	wd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get working directory: %w", err)
@@ -45,7 +45,7 @@ func createMeta(diffCmd []string) error {
 		return fmt.Errorf("failed to run git rev-parse: %w", err)
 	}
 	if len(branch) == 0 {
-		return fmt.Errorf("git rev-parse command produced no output: %v", diffCmd)
+		return fmt.Errorf("git rev-parse command produced no output")
 	}
 
 	remote, err := exec.Command("git", "remote", "get-url", "origin").Output()
@@ -63,7 +63,7 @@ func createMeta(diffCmd []string) error {
 		PatchName:     patchName,
 		CurrentBranch: strings.TrimSpace(string(branch)),
 		DirName:       filepath.Base(wd),
-		DiffCmd:       strings.Join(diffCmd, " "),
+		DiffCmd:       rev,
 		Remote:        strings.TrimSpace(string(remote)),
 		GitDirty:      len(status) != 0,
 	}

--- a/pkg/repo/scanner.go
+++ b/pkg/repo/scanner.go
@@ -28,10 +28,10 @@ const (
 	tarballDir  = "kusari-dir"
 )
 
-func Scan(dir string, diffCmd []string, platformUrl string, consoleUrl string, verbose bool, wait bool) error {
+func Scan(dir string, rev string, platformUrl string, consoleUrl string, verbose bool, wait bool) error {
 	if verbose {
 		fmt.Fprintf(os.Stderr, " dir: %s\n", dir)
-		fmt.Fprintf(os.Stderr, " diffCmd: %s\n", strings.Join(diffCmd, " "))
+		fmt.Fprintf(os.Stderr, " rev: %s\n", rev)
 		fmt.Fprintf(os.Stderr, " platformUrl: %s\n", platformUrl)
 		fmt.Fprintf(os.Stderr, " consoleUrl: %s\n", consoleUrl)
 	}
@@ -58,13 +58,13 @@ func Scan(dir string, diffCmd []string, platformUrl string, consoleUrl string, v
 		_ = os.Chdir(wd)
 	}()
 
-	if err := createMeta(diffCmd); err != nil {
+	if err := createMeta(rev); err != nil {
 		return fmt.Errorf("failed to package directory: %w", err)
 	}
 
 	fmt.Fprint(os.Stderr, "Generating diff...\n")
 
-	if err := generateDiff(dir, diffCmd); err != nil {
+	if err := generateDiff(rev); err != nil {
 		return fmt.Errorf("failed to generate diff: %w", err)
 	}
 
@@ -113,9 +113,8 @@ func Scan(dir string, diffCmd []string, platformUrl string, consoleUrl string, v
 	// Wait for results if the user wants, or exit immediately
 	if wait {
 		return queryForResult(platformUrl, epoch, token.AccessToken, consoleFullUrl)
-	} else {
-		return nil
 	}
+	return nil
 }
 
 func queryForResult(platformUrl string, epoch *string, accessToken string, consoleFullUrl *string) error {


### PR DESCRIPTION
Only take a single argument that must be a valid git revision. Then the diff command will always compare that rev to the working tree, so that the patch will always apply (reverse) to the tarball.