### PR TITLE
Rename `configuration` and shorten subcommands

### DIFF
--- a/kusari/cmd/configuration.go
+++ b/kusari/cmd/configuration.go
@@ -4,10 +4,11 @@ import "github.com/spf13/cobra"
 
 func KusariConfiguration() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "configuration",
+		Use:   "config",
 		Short: "Configuration actions",
 		// Keep it simple for now and expand as more commands get added
-		Long: "Generate kusari-cli configuration file",
+		Long:    "Generate kusari-cli configuration file",
+		Aliases: []string{"configuration"}, // alias to help existing users. Drop for 1.0
 	}
 
 	cmd.AddCommand(generateConfig())

--- a/kusari/cmd/configuration_generate_config.go
+++ b/kusari/cmd/configuration_generate_config.go
@@ -29,7 +29,7 @@ func generateConfig() *cobra.Command {
 }
 
 var generatecmd = &cobra.Command{
-	Use:   "generate-config",
+	Use:   "generate",
 	Short: fmt.Sprintf("Generate %s config file", configuration.ConfigFilename),
 	Long: fmt.Sprintf("Generate a %s config file for kusari-cli "+
 		"with default values.", configuration.ConfigFilename),
@@ -37,4 +37,5 @@ var generatecmd = &cobra.Command{
 		// Update from viper (this gets env vars + config + flags)
 		forceWrite = viper.GetBool("force")
 	},
+	Aliases: []string{"generate-config"}, // alias to help existing users. Drop for 1.0
 }

--- a/kusari/cmd/configuration_update_config.go
+++ b/kusari/cmd/configuration_update_config.go
@@ -21,8 +21,9 @@ func updateConfig() *cobra.Command {
 }
 
 var updatecmd = &cobra.Command{
-	Use:   "update-config",
+	Use:   "update",
 	Short: fmt.Sprintf("Update %s config file", configuration.ConfigFilename),
 	Long: fmt.Sprintf("Update a %s config file for kusari-cli "+
 		"with new values.", configuration.ConfigFilename),
+	Aliases: []string{"update-config"}, // alias to help existing users. Drop for 1.0
 }


### PR DESCRIPTION
This makes the commands shorter (and less duplicative) without being
unclear. Include aliases for backward compatibility.

Fixes #71

Signed-off-by: Ben Cotton <ben@kusari.dev>