### PR TITLE
add api key console result output

### DIFF
--- a/pkg/repo/scanner.go
+++ b/pkg/repo/scanner.go
@@ -176,12 +176,12 @@ func scan(dir string, rev string, platformUrl string, consoleUrl string, verbose
 		return fmt.Errorf("failed to upload file to S3: %w", err)
 	}
 
-	workspaceID, userID, epoch, err := urlBuilder.GetIDsFromUrl(presignedUrl)
+	workspaceID, userID, epoch, isMachine, err := urlBuilder.GetIDsFromUrl(presignedUrl)
 	if err != nil {
 		return err
 	}
 
-	sortString := urlBuilder.CreateSortString(userID, epoch, full)
+	sortString := urlBuilder.CreateSortString(userID, epoch, full, isMachine)
 
 	consoleFullUrl, err := urlBuilder.Build(consoleUrl, "workspaces", workspaceID, "analysis", sortString, "result")
 	if err != nil {

--- a/pkg/url/build_test.go
+++ b/pkg/url/build_test.go
@@ -12,23 +12,27 @@ func Test_Build_Base(t *testing.T) {
 	assert.Nil(t, e)
 	assert.Equal(t, "https://jerry.wilson", *actual)
 }
+
 func Test_Build_Hostname_Error(t *testing.T) {
 	_, e := Build("*****")
 
 	assert.NotNil(t, e)
 }
+
 func Test_Build_Base_Trailing_Slash(t *testing.T) {
 	actual, e := Build("https://jerry.wilson/")
 
 	assert.Nil(t, e)
 	assert.Equal(t, "https://jerry.wilson/", *actual)
 }
+
 func Test_Build_Path(t *testing.T) {
 	actual, e := Build("https://jerry.wilson", "a", "b")
 
 	assert.Nil(t, e)
 	assert.Equal(t, "https://jerry.wilson/a/b", *actual)
 }
+
 func Test_Build_Path_Trailing_Slash(t *testing.T) {
 	actual, e := Build("https://jerry.wilson/", "a", "b")
 
@@ -36,32 +40,46 @@ func Test_Build_Path_Trailing_Slash(t *testing.T) {
 	assert.Equal(t, "https://jerry.wilson/a/b", *actual)
 }
 
-func Test_GetIDsFromUrl_Success(t *testing.T) {
-	presignUrl := "https://inspector-bundle-upload-dev-us-east-1.s3.us-east-1.amazonaws.com/workspace/4382f4d8-3a11-401f-a9ba-3b1702f6917e/user/human/6a5404db-a484-4115-8a69-a9def45a8fe3/diff/blob/1761082861?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAS7LCAOM53APYAJ26%2F20251021%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20251021T214101Z&X-Amz-Expires=300&X-Amz-Security-Token=asdf1234qwer4567&X-Amz-SignedHeaders=host&x-id=PutObject&X-Amz-Signature=aafacd4d8cd5c1a1aa405138b516c37db775698d75f4a798dbb8f0e6a6009378"
+func Test_GetIDsFromUrl_Success_Machine(t *testing.T) {
+	presignUrl := "https://inspector-bundle-upload-dev-us-east-1.s3.us-east-1.amazonaws.com/workspace/4382f4d8-3a11-401f-a9ba-3b1702f6917e/user/machine/6a5404db-a484-4115-8a69-a9def45a8fe3/diff/blob/1761082861?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAS7LCAOM53APYAJ26%2F20251021%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20251021T214101Z&X-Amz-Expires=300&X-Amz-Security-Token=asdf1234qwer4567&X-Amz-SignedHeaders=host&x-id=PutObject&X-Amz-Signature=aafacd4d8cd5c1a1aa405138b516c37db775698d75f4a798dbb8f0e6a6009378"
 
-	workspaceID, userID, epoch, err := GetIDsFromUrl(presignUrl)
+	workspaceID, userID, epoch, isMachine, err := GetIDsFromUrl(presignUrl)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "4382f4d8-3a11-401f-a9ba-3b1702f6917e", workspaceID)
 	assert.Equal(t, "6a5404db-a484-4115-8a69-a9def45a8fe3", userID)
+	assert.True(t, isMachine)
+	assert.Equal(t, "1761082861", epoch)
+}
+
+func Test_GetIDsFromUrl_Success_Human(t *testing.T) {
+	presignUrl := "https://inspector-bundle-upload-dev-us-east-1.s3.us-east-1.amazonaws.com/workspace/4382f4d8-3a11-401f-a9ba-3b1702f6917e/user/human/6a5404db-a484-4115-8a69-a9def45a8fe3/diff/blob/1761082861?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAS7LCAOM53APYAJ26%2F20251021%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20251021T214101Z&X-Amz-Expires=300&X-Amz-Security-Token=asdf1234qwer4567&X-Amz-SignedHeaders=host&x-id=PutObject&X-Amz-Signature=aafacd4d8cd5c1a1aa405138b516c37db775698d75f4a798dbb8f0e6a6009378"
+
+	workspaceID, userID, epoch, isMachine, err := GetIDsFromUrl(presignUrl)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "4382f4d8-3a11-401f-a9ba-3b1702f6917e", workspaceID)
+	assert.Equal(t, "6a5404db-a484-4115-8a69-a9def45a8fe3", userID)
+	assert.False(t, isMachine)
 	assert.Equal(t, "1761082861", epoch)
 }
 
 func Test_GetIDsFromUrl_NoQueryParams(t *testing.T) {
 	presignUrl := "https://example.com/workspace/test-workspace-id/user/human/test-user-id/diff/blob/123"
 
-	workspaceID, userID, epoch, err := GetIDsFromUrl(presignUrl)
+	workspaceID, userID, epoch, isMachine, err := GetIDsFromUrl(presignUrl)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "test-workspace-id", workspaceID)
 	assert.Equal(t, "test-user-id", userID)
+	assert.False(t, isMachine)
 	assert.Equal(t, "123", epoch)
 }
 
 func Test_GetIDsFromUrl_MissingWorkspace(t *testing.T) {
 	presignUrl := "https://example.com/user/human/test-user-id/diff/blob/123"
 
-	_, _, _, err := GetIDsFromUrl(presignUrl)
+	_, _, _, _, err := GetIDsFromUrl(presignUrl)
 
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "workspace ID not found")
@@ -70,7 +88,7 @@ func Test_GetIDsFromUrl_MissingWorkspace(t *testing.T) {
 func Test_GetIDsFromUrl_MissingUser(t *testing.T) {
 	presignUrl := "https://example.com/workspace/test-workspace-id/diff/blob/123"
 
-	_, _, _, err := GetIDsFromUrl(presignUrl)
+	_, _, _, _, err := GetIDsFromUrl(presignUrl)
 
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "user ID not found")
@@ -79,65 +97,114 @@ func Test_GetIDsFromUrl_MissingUser(t *testing.T) {
 func Test_GetIDsFromUrl_InvalidURL(t *testing.T) {
 	presignUrl := "://invalid-url"
 
-	_, _, _, err := GetIDsFromUrl(presignUrl)
+	_, _, _, _, err := GetIDsFromUrl(presignUrl)
 
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "error parsing URL")
 }
 
-func Test_CreateSortString_Basic(t *testing.T) {
+// CreateSortString tests for cli-user (human users)
+func Test_CreateSortString_Basic_Human(t *testing.T) {
 	userID := "6a5404db-a484-4115-8a69-a9def45a8fe3"
 	epoch := "1761082861"
 
-	result := CreateSortString(userID, epoch, false)
+	result := CreateSortString(userID, epoch, false, false)
 
 	assert.Equal(t, "cli-user%7C6a5404db-a484-4115-8a69-a9def45a8fe3%7C1761082861", result)
 }
 
-func Test_CreateSortString_Full(t *testing.T) {
+func Test_CreateSortString_Full_Human(t *testing.T) {
 	userID := "6a5404db-a484-4115-8a69-a9def45a8fe3"
 	epoch := "1761082861"
 
-	result := CreateSortString(userID, epoch, true)
+	result := CreateSortString(userID, epoch, true, false)
 
 	assert.Equal(t, "cli-user-full%7C6a5404db-a484-4115-8a69-a9def45a8fe3%7C1761082861", result)
+}
+
+// CreateSortString tests for cli-api (machine users)
+func Test_CreateSortString_Basic_Machine(t *testing.T) {
+	userID := "6a5404db-a484-4115-8a69-a9def45a8fe3"
+	epoch := "1761082861"
+
+	result := CreateSortString(userID, epoch, false, true)
+
+	assert.Equal(t, "cli-api%7Cmachine%7C1761082861", result)
+}
+
+func Test_CreateSortString_Full_Machine(t *testing.T) {
+	userID := "6a5404db-a484-4115-8a69-a9def45a8fe3"
+	epoch := "1761082861"
+
+	result := CreateSortString(userID, epoch, true, true)
+
+	assert.Equal(t, "cli-api-full%7Cmachine%7C1761082861", result)
 }
 
 func Test_CreateSortString_WithSpecialChars(t *testing.T) {
 	userID := "user@example.com"
 	epoch := "2024/10/21"
 
-	result := CreateSortString(userID, epoch, false)
+	result := CreateSortString(userID, epoch, false, false)
 
 	assert.Equal(t, "cli-user%7Cuser%40example.com%7C2024%2F10%2F21", result)
 }
 
-func Test_CreateSortString_EmptyValues(t *testing.T) {
-	result := CreateSortString("", "", false)
+func Test_CreateSortString_EmptyValues_Human(t *testing.T) {
+	result := CreateSortString("", "", false, false)
 
 	assert.Equal(t, "cli-user%7C%7C", result)
 }
 
-func Test_CreateSortString_Integration(t *testing.T) {
-	// Test that we can use the output from GetIDsFromUrl
+func Test_CreateSortString_EmptyValues_Machine(t *testing.T) {
+	result := CreateSortString("", "", false, true)
+
+	assert.Equal(t, "cli-api%7Cmachine%7C", result)
+}
+
+// Integration tests
+func Test_CreateSortString_Integration_Human(t *testing.T) {
 	presignUrl := "https://inspector-bundle-upload-dev-us-east-1.s3.us-east-1.amazonaws.com/workspace/4382f4d8-3a11-401f-a9ba-3b1702f6917e/user/human/6a5404db-a484-4115-8a69-a9def45a8fe3/diff/blob/1761082861?X-Amz-Algorithm=AWS4-HMAC-SHA256"
 
-	_, userID, epoch, err := GetIDsFromUrl(presignUrl)
+	_, userID, epoch, isMachine, err := GetIDsFromUrl(presignUrl)
 	assert.Nil(t, err)
 
-	result := CreateSortString(userID, epoch, false)
+	result := CreateSortString(userID, epoch, false, isMachine)
 
 	assert.Equal(t, "cli-user%7C6a5404db-a484-4115-8a69-a9def45a8fe3%7C1761082861", result)
 }
 
-func Test_CreateSortString_Integration_Full(t *testing.T) {
-	// Test that we can use the output from GetIDsFromUrl with full=true
+func Test_CreateSortString_Integration_Human_Full(t *testing.T) {
 	presignUrl := "https://inspector-bundle-upload-dev-us-east-1.s3.us-east-1.amazonaws.com/workspace/4382f4d8-3a11-401f-a9ba-3b1702f6917e/user/human/6a5404db-a484-4115-8a69-a9def45a8fe3/diff/blob/1761082861?X-Amz-Algorithm=AWS4-HMAC-SHA256"
 
-	_, userID, epoch, err := GetIDsFromUrl(presignUrl)
+	_, userID, epoch, isMachine, err := GetIDsFromUrl(presignUrl)
 	assert.Nil(t, err)
 
-	result := CreateSortString(userID, epoch, true)
+	result := CreateSortString(userID, epoch, true, isMachine)
 
 	assert.Equal(t, "cli-user-full%7C6a5404db-a484-4115-8a69-a9def45a8fe3%7C1761082861", result)
+}
+
+func Test_CreateSortString_Integration_Machine(t *testing.T) {
+	presignUrl := "https://inspector-bundle-upload-dev-us-east-1.s3.us-east-1.amazonaws.com/workspace/4382f4d8-3a11-401f-a9ba-3b1702f6917e/user/machine/6a5404db-a484-4115-8a69-a9def45a8fe3/diff/blob/1761082861?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+
+	_, userID, epoch, isMachine, err := GetIDsFromUrl(presignUrl)
+	assert.Nil(t, err)
+	assert.True(t, isMachine)
+
+	result := CreateSortString(userID, epoch, false, isMachine)
+
+	assert.Equal(t, "cli-api%7Cmachine%7C1761082861", result)
+}
+
+func Test_CreateSortString_Integration_Machine_Full(t *testing.T) {
+	presignUrl := "https://inspector-bundle-upload-dev-us-east-1.s3.us-east-1.amazonaws.com/workspace/4382f4d8-3a11-401f-a9ba-3b1702f6917e/user/machine/6a5404db-a484-4115-8a69-a9def45a8fe3/diff/blob/1761082861?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+
+	_, userID, epoch, isMachine, err := GetIDsFromUrl(presignUrl)
+	assert.Nil(t, err)
+	assert.True(t, isMachine)
+
+	result := CreateSortString(userID, epoch, true, isMachine)
+
+	assert.Equal(t, "cli-api-full%7Cmachine%7C1761082861", result)
 }

--- a/pkg/url/epoch.go
+++ b/pkg/url/epoch.go
@@ -8,12 +8,33 @@ import (
 )
 
 // CreateSortString creates a URL-encoded sort string from user ID and epoch.
-// Format: "cli-user|{userID}|{epoch}" or "cli-user-full|{userID}|{epoch}" (URL-encoded)
-func CreateSortString(userID string, epoch string, full bool) string {
-	prefix := "cli-user"
-	if full {
-		prefix = "cli-user-full"
+/* Sort Key format:
+
+cli-user: cli-user|{{user sub}}|{{epoch}}
+cli-user-full: cli-user-full|{{user sub}}|{{epoch}}
+cli-api: cli-api|machine|{{epoch}}
+cli-api-full: cli-api-full|machine|{{epoch}}
+cli-user: cli-user|{{user sub}}|{{timestamp}}|status|{{status}}
+cli-user-full: cli-user-full|{{user sub}}|{{timestamp}}|status|{{status}}
+cli-api: cli-api|machine|{{timestamp}}|status|{{status}}
+cli-api-full: cli-api-full|machine|{{timestamp}}|status|{{status}}
+*/
+func CreateSortString(userID string, epoch string, full, isMachine bool) string {
+	var prefix string
+
+	if !isMachine {
+		prefix = "cli-user"
+		if full {
+			prefix = "cli-user-full"
+		}
+	} else {
+		prefix = "cli-api"
+		if full {
+			prefix = "cli-api-full"
+		}
+		userID = "machine"
 	}
+
 	sortString := fmt.Sprintf("%s|%s|%s", prefix, userID, epoch)
 	return url.QueryEscape(sortString)
 }
@@ -21,16 +42,17 @@ func CreateSortString(userID string, epoch string, full bool) string {
 // GetIDsFromUrl extracts the workspace ID, user ID, and epoch from a presigned URL.
 // Returns workspaceID, userID, epoch, error.
 // Expected URL format: .../workspace/{workspaceID}/user/{userType}/{userID}/.../{epoch}
-func GetIDsFromUrl(presignUrl string) (string, string, string, error) {
+func GetIDsFromUrl(presignUrl string) (string, string, string, bool, error) {
 	u, err := url.Parse(presignUrl)
 	if err != nil {
-		return "", "", "", fmt.Errorf("error parsing URL: %w", err)
+		return "", "", "", false, fmt.Errorf("error parsing URL: %w", err)
 	}
 
 	// Split the path into segments
 	segments := strings.Split(strings.Trim(u.Path, "/"), "/")
 
-	var workspaceID, userID string
+	var workspaceID, userID, isMachineStr string
+	var isMachine bool
 
 	// Find workspace ID
 	for i, segment := range segments {
@@ -40,6 +62,7 @@ func GetIDsFromUrl(presignUrl string) (string, string, string, error) {
 		if segment == "user" && i+2 < len(segments) {
 			// Skip userType (segments[i+1]) and get userID (segments[i+2])
 			userID = segments[i+2]
+			isMachineStr = segments[i+1]
 		}
 	}
 
@@ -47,14 +70,17 @@ func GetIDsFromUrl(presignUrl string) (string, string, string, error) {
 	epoch := path.Base(u.Path)
 
 	if workspaceID == "" {
-		return "", "", "", fmt.Errorf("workspace ID not found in URL")
+		return "", "", "", false, fmt.Errorf("workspace ID not found in URL")
 	}
 	if userID == "" {
-		return "", "", "", fmt.Errorf("user ID not found in URL")
+		return "", "", "", false, fmt.Errorf("user ID not found in URL")
 	}
 	if epoch == "" || epoch == "/" {
-		return "", "", "", fmt.Errorf("epoch not found in URL")
+		return "", "", "", false, fmt.Errorf("epoch not found in URL")
+	}
+	if isMachineStr == "machine" {
+		isMachine = true
 	}
 
-	return workspaceID, userID, epoch, nil
+	return workspaceID, userID, epoch, isMachine, nil
 }


### PR DESCRIPTION
add support for all sort key formats:

/* Sort Key format:

cli-user: cli-user|{{user sub}}|{{epoch}}
cli-user-full: cli-user-full|{{user sub}}|{{epoch}}
cli-api: cli-api|machine|{{epoch}}
cli-api-full: cli-api-full|machine|{{epoch}}
cli-user: cli-user|{{user sub}}|{{timestamp}}|status|{{status}}
cli-user-full: cli-user-full|{{user sub}}|{{timestamp}}|status|{{status}}
cli-api: cli-api|machine|{{timestamp}}|status|{{status}}
cli-api-full: cli-api-full|machine|{{timestamp}}|status|{{status}}
*/


tested in dev