### PR TITLE
fix issue where github and google could have differnt workspaces - fetch and write each time

### DIFF
--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -28,32 +28,17 @@ func Login(ctx context.Context, clientId, clientSecret, redirectUrl, authEndpoin
 		fmt.Println()
 	}
 
-	// Check if there's a previously stored workspace for this platform and auth endpoint
-	// This allows us to include the workspace in the redirect URL
-	workspaceId := ""
-	previousWorkspace, _ := auth.LoadWorkspace(platformUrl, currentAuthEndpoint)
-	if previousWorkspace != nil {
-		workspaceId = previousWorkspace.ID
-		fmt.Printf("\nUsing stored workspace: %s\n", previousWorkspace.Description)
-	}
-
-	token, err := auth.Authenticate(ctx, clientId, clientSecret, redirectUrl, authEndpoint, redirectPort, consoleUrl, workspaceId)
+	// Always authenticate without a pre-selected workspace
+	// This ensures we fetch fresh workspace information each time
+	token, err := auth.Authenticate(ctx, clientId, clientSecret, redirectUrl, authEndpoint, redirectPort, consoleUrl, "")
 	if err != nil {
 		return err
 	}
 
 	fmt.Println("Successfully logged in!")
 
-	// If we already had a workspace, we're done
-	if previousWorkspace != nil {
-		fmt.Printf("\nYour current workspace is: %s\n", previousWorkspace.Description)
-		fmt.Println("To change workspaces, run: kusari auth select-workspace")
-		fmt.Println("\033[1m\033[34mFor more information, visit:\033[0m https://docs.kusari.cloud")
-		return nil
-	}
-
-	// No workspace stored - fetch available workspaces and prompt user to select
-	fmt.Println("\nNo workspace configured. Let's set one up.")
+	// Always fetch fresh workspaces and prompt user to select
+	fmt.Println("\nFetching your workspaces...")
 	workspaces, workspaceTenants, err := FetchWorkspaces(platformUrl, token.AccessToken)
 	if err != nil {
 		return fmt.Errorf("failed to fetch workspaces: %w", err)


### PR DESCRIPTION
- kusari auth login was keeping some old workspace values around from a previous login, even when run a second time
so it would try to access an old workspace that the new login didn't have access to
- this can happen when a person has multiple login methods: I can login using Google or GitHub, and they have access to different workspaces

Fixed to fetch and store new values each time on kusari auth login.

So login via github or google (different accounts in dev) will not modify the workspace.json file:

```
➜  .kusari cat workspace.json
{
  "id": "efc46304-e0ef-4101-8d1f-8d30084fc835",
  "description": "My Workspace",
  "platformUrl": "https://platform.api.dev.kusari.cloud/",
  "authEndpoint": "https://auth.dev.kusari.cloud/",
  "tenant": "parth"
}%
➜  .kusari cat workspace.json
{
  "id": "be30c9f1-86b2-4aff-96e4-80a66a8d9017",
  "description": "My Workspace",
  "platformUrl": "https://platform.api.dev.kusari.cloud/",
  "authEndpoint": "https://auth.dev.kusari.cloud/",
  "tenant": ""
}%
```