### PR TITLE
Fix risk check on monorepos

### DIFF
--- a/kusari/cmd/repo_risk_check.go
+++ b/kusari/cmd/repo_risk_check.go
@@ -8,8 +8,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var scanSubprojects bool
+
 func init() {
 	riskcheckcmd.Flags().BoolVarP(&wait, "wait", "w", true, "wait for results")
+	riskcheckcmd.Flags().BoolVar(&scanSubprojects, "scan-subprojects", false, "automatically scan each detected subproject in a monorepo")
 }
 
 func riskcheck() *cobra.Command {
@@ -18,7 +21,7 @@ func riskcheck() *cobra.Command {
 
 		dir := args[0]
 
-		return repo.RiskCheck(dir, platformUrl, consoleUrl, verbose, wait)
+		return repo.RiskCheck(dir, platformUrl, consoleUrl, verbose, wait, scanSubprojects)
 	}
 
 	return riskcheckcmd
@@ -28,6 +31,9 @@ var riskcheckcmd = &cobra.Command{
 	Use:   "risk-check <directory>",
 	Short: "Risk-check a repo with Kusari Inspector",
 	Long: `Submit the directory for summary analysis in Kusari Inspector.
-    <directory>  A directory containing a git repository to analyze`,
+    <directory>  A directory containing a git repository to analyze.
+
+For monorepos, use --scan-subprojects to automatically scan all detected subprojects,
+or specify a subproject directory directly.`,
 	Args: cobra.ExactArgs(1),
 }

--- a/pkg/repo/packager.go
+++ b/pkg/repo/packager.go
@@ -95,7 +95,8 @@ func createMeta(rev string, full bool) (*api.BundleMeta, error) {
 		remote = []byte{}
 	}
 
-	status, err := exec.Command("git", "status", "--porcelain").Output()
+	// Use "-- ." to scope git status to the current directory (for subdirectory scans)
+	status, err := exec.Command("git", "status", "--porcelain", "--", ".").Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to run git status: %w", err)
 	}

--- a/pkg/repo/scanner_test.go
+++ b/pkg/repo/scanner_test.go
@@ -73,7 +73,7 @@ func TestScan_ArchiveFormat(t *testing.T) {
 		}
 
 		// Run the scan with dependencies injection
-		err := scan(testDir, "HEAD", "https://platform.example.com", "https://console.example.com", false, false, full, "markdown", mock)
+		err := scan(testDir, "HEAD", "https://platform.example.com", "https://console.example.com", false, false, full, "markdown", false, mock)
 		require.NoError(t, err)
 
 		// Verify upload was called
@@ -407,7 +407,7 @@ func TestDetectMonoRepo(t *testing.T) {
 			}
 
 			// Run detection
-			isMonoRepo, indicators, err := detectMonoRepo(testDir)
+			isMonoRepo, indicators, _, err := detectMonoRepo(testDir)
 			require.NoError(t, err)
 
 			// Verify results
@@ -475,7 +475,7 @@ func TestMonoRepoCheck_OnlyForRiskCheck(t *testing.T) {
 
 	t.Run("diff scan should succeed on monorepo", func(t *testing.T) {
 		// Diff scan (full=false) should succeed even with monorepo
-		err := scan(testDir, "HEAD", "https://platform.example.com", "https://console.example.com", false, false, false, "markdown", mock)
+		err := scan(testDir, "HEAD", "https://platform.example.com", "https://console.example.com", false, false, false, "markdown", false, mock)
 		assert.NoError(t, err, "diff scan should succeed on monorepo")
 	})
 
@@ -483,7 +483,7 @@ func TestMonoRepoCheck_OnlyForRiskCheck(t *testing.T) {
 		// Risk check (full=true) should detect monorepo and exit
 		// Since the code calls os.Exit(1), we can't directly test this in a unit test
 		// Instead, we verify that detectMonoRepo correctly identifies it
-		isMonoRepo, indicators, err := detectMonoRepo(testDir)
+		isMonoRepo, indicators, _, err := detectMonoRepo(testDir)
 		require.NoError(t, err)
 		assert.True(t, isMonoRepo, "should detect monorepo")
 		assert.Contains(t, indicators, "monorepo config: lerna.json", "should detect lerna.json")


### PR DESCRIPTION
Risk check was failing on monorepos because it was expecting each subproject to be its own individual git repo which is not usually the case.

This change both fixes the issue and adds a --scan-subprojects flag for just concurrently scanning all subprojects.

Ideally in the future we build a design that thinks of monorepos and subprojects as first class citizens.