### PR TITLE
Remove component-name from platform upload and configuration

### DIFF
--- a/api/configuration/config.go
+++ b/api/configuration/config.go
@@ -10,7 +10,6 @@ type Config struct {
 
 	// SBOM Generation Configuration (for merged PRs to main/master)
 	SBOMGenerationEnabled      bool   `yaml:"sbom_generation_enabled"`                 // Enable SBOM generation on merged PRs (default: false)
-	SBOMComponentName          string `yaml:"sbom_component_name,omitempty"`           // Custom component name for SBOM (default: GitHub repo name)
 	SBOMSubjectNameOverride    string `yaml:"sbom_subject_name_override,omitempty"`    // Override SBOM subject name in Kusari Platform
 	SBOMSubjectVersionOverride string `yaml:"sbom_subject_version_override,omitempty"` // Override SBOM subject version in Kusari Platform
 }

--- a/kusari/cmd/upload.go
+++ b/kusari/cmd/upload.go
@@ -4,6 +4,9 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/kusaridev/kusari-cli/pkg/repo"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -38,6 +41,9 @@ func init() {
 	uploadcmd.Flags().StringVar(&uploadSoftwareID, "software-id", "", "Kusari Platform Software ID value to set in the document wrapper upload meta (optional)")
 	uploadcmd.Flags().StringVar(&uploadSbomSubject, "sbom-subject", "", "Kusari Platform Software sbom subject substring value to set in the document wrapper upload meta (optional, for OpenVEX docs only)")
 	uploadcmd.Flags().StringVar(&uploadComponentName, "component-name", "", "Kusari Platform component name (optional)")
+	if err := uploadcmd.Flags().MarkDeprecated("component-name", "see https://docs.us.kusari.cloud/software/components for info on how to assign and use Components"); err != nil {
+		panic(err)
+	}
 	uploadcmd.Flags().BoolVar(&uploadCheckBlocked, "check-blocked-packages", false, "Check if any of the SBOMs uses a package contained in the blocked package list")
 	uploadcmd.Flags().StringVar(&uploadSbomSubjectNameOverride, "sbom-subject-name-override", "", "SBOM Subject Name override (optional, for SBOMs only)")
 	uploadcmd.Flags().StringVar(&uploadSbomSubjectVersionOverride, "sbom-subject-version-override", "", "SBOM Subject Version override (optional, from SBOMs only)")
@@ -72,6 +78,13 @@ func upload() *cobra.Command {
 	uploadcmd.RunE = func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
+		// CLI uses of --component-name are warned about by cobra's MarkDeprecated.
+		// Cover the config-file and env-var paths here.
+		if uploadComponentName != "" && !cmd.Flags().Changed("component-name") {
+			fmt.Fprintln(os.Stderr, "The component-name config value is no longer supported. "+
+				"See https://docs.us.kusari.cloud/software/components for info on how to assign and use Components.")
+		}
+
 		return repo.Upload(
 			uploadFilePath,
 			platformTenantEndpoint,
@@ -82,7 +95,6 @@ func upload() *cobra.Command {
 			uploadTag,
 			uploadSoftwareID,
 			uploadSbomSubject,
-			uploadComponentName,
 			uploadSbomSubjectNameOverride,
 			uploadSbomSubjectVersionOverride,
 			uploadCheckBlocked,

--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -23,7 +23,6 @@ var DefaultConfig = configuration.Config{
 	FullCodeReviewEnabled:                  false,
 	// SBOM Generation is disabled by default to avoid breaking existing implementations
 	SBOMGenerationEnabled:      false,
-	SBOMComponentName:          "", // Empty means use GitHub repo name as default
 	SBOMSubjectNameOverride:    "",
 	SBOMSubjectVersionOverride: "",
 }
@@ -93,7 +92,7 @@ func mergeConfigs(defaultConfig configuration.Config, existingConfig map[string]
 		yamlTag := field.Tag.Get("yaml")
 
 		// Parse the yaml tag to extract just the field name (before any comma)
-		// e.g., "sbom_component_name,omitempty" -> "sbom_component_name"
+		// e.g., "sbom_subject_name_override,omitempty" -> "sbom_subject_name_override"
 		yamlFieldName := yamlTag
 		if commaIdx := findComma(yamlTag); commaIdx != -1 {
 			yamlFieldName = yamlTag[:commaIdx]

--- a/pkg/configuration/config_test.go
+++ b/pkg/configuration/config_test.go
@@ -155,7 +155,6 @@ func TestUpdatePreservesSBOMConfig(t *testing.T) {
 
 	// Verify SBOM fields are preserved
 	require.Contains(t, content, "sbom_generation_enabled: true")
-	require.Contains(t, content, "sbom_component_name: my-custom-component")
 	require.Contains(t, content, "sbom_subject_name_override: custom-subject")
 	require.Contains(t, content, "sbom_subject_version_override: v1.0.0")
 
@@ -165,7 +164,6 @@ func TestUpdatePreservesSBOMConfig(t *testing.T) {
 // Test that default SBOM config has generation disabled
 func TestDefaultSBOMConfigDisabled(t *testing.T) {
 	require.False(t, DefaultConfig.SBOMGenerationEnabled, "SBOM generation should be disabled by default")
-	require.Empty(t, DefaultConfig.SBOMComponentName, "SBOM component name should be empty by default")
 	require.Empty(t, DefaultConfig.SBOMSubjectNameOverride, "SBOM subject name override should be empty by default")
 	require.Empty(t, DefaultConfig.SBOMSubjectVersionOverride, "SBOM subject version override should be empty by default")
 }
@@ -192,7 +190,6 @@ func TestGeneratedConfigOmitsEmptySBOMFields(t *testing.T) {
 	require.Contains(t, content, "sbom_generation_enabled: false")
 
 	// Empty string fields should NOT be present (they have omitempty)
-	require.NotContains(t, content, "sbom_component_name")
 	require.NotContains(t, content, "sbom_subject_name_override")
 	require.NotContains(t, content, "sbom_subject_version_override")
 

--- a/pkg/configuration/testdata/config-sbom-enabled.yaml
+++ b/pkg/configuration/testdata/config-sbom-enabled.yaml
@@ -5,6 +5,5 @@ post_comment_on_failure: true
 post_comment_on_success: false
 full_code_review_enabled: false
 sbom_generation_enabled: true
-sbom_component_name: my-custom-component
 sbom_subject_name_override: custom-subject
 sbom_subject_version_override: v1.0.0

--- a/pkg/repo/uploader.go
+++ b/pkg/repo/uploader.go
@@ -110,13 +110,12 @@ type StatusMeta struct {
 
 // IngestionStatusItem represents an item in the pico-ingestion-status DynamoDB table
 type IngestionStatusItem struct {
-	Workspace     string     `json:"workspace"`      // partition key
-	Sort          string     `json:"sort"`           // sort key
-	DocumentType  string     `json:"document_type"`  // SBOM, VEX, etc.
-	DocumentName  string     `json:"document_name"`  // Name of the ingested document
-	ComponentName string     `json:"component_name"` // Component name from upload metadata
-	TTL           int64      `json:"ttl"`            // TTL in Unix epoch seconds
-	StatusMeta    StatusMeta `json:"statusMeta"`
+	Workspace    string     `json:"workspace"`     // partition key
+	Sort         string     `json:"sort"`          // sort key
+	DocumentType string     `json:"document_type"` // SBOM, VEX, etc.
+	DocumentName string     `json:"document_name"` // Name of the ingested document
+	TTL          int64      `json:"ttl"`           // TTL in Unix epoch seconds
+	StatusMeta   StatusMeta `json:"statusMeta"`
 }
 
 type cdxSBOM struct {
@@ -146,7 +145,6 @@ func Upload(
 	tag string,
 	softwareID string,
 	sbomSubject string,
-	componentName string,
 	sbomSubjectNameOverride string,
 	sbomSubjectVersionOverride string,
 	checkBlockedPackages bool,
@@ -264,9 +262,6 @@ func Upload(
 	if sbomSubject != "" { // only used for VEX
 		uploadMeta["sbom_subject"] = sbomSubject
 	}
-	if componentName != "" {
-		uploadMeta["component_name"] = componentName
-	}
 	if sbomSubjectNameOverride != "" { // only used for SBOM
 		uploadMeta["sbom_subject_name_override"] = sbomSubjectNameOverride
 	}
@@ -324,12 +319,11 @@ func Upload(
 	// Query ingestion status for each uploaded document
 	if wait && workspace != "" && tenantName != "" {
 		type ingestionResult struct {
-			docRef        string
-			documentName  string
-			componentName string
-			status        string
-			userMessage   string
-			err           error
+			docRef       string
+			documentName string
+			status       string
+			userMessage  string
+			err          error
 		}
 
 		// Filter out empty docRefs
@@ -358,11 +352,10 @@ func Upload(
 						// Update results with interim status changes (started, processing, etc.)
 						resultsMutex.Lock()
 						results[i] = ingestionResult{
-							docRef:        ssau.docRef,
-							documentName:  statusItem.DocumentName,
-							componentName: statusItem.ComponentName,
-							status:        statusItem.StatusMeta.Status,
-							userMessage:   statusItem.StatusMeta.UserMessage,
+							docRef:       ssau.docRef,
+							documentName: statusItem.DocumentName,
+							status:       statusItem.StatusMeta.Status,
+							userMessage:  statusItem.StatusMeta.UserMessage,
 						}
 						// Print live status update (truncate docRef for readability)
 						shortDocRef := ssau.docRef
@@ -382,11 +375,10 @@ func Upload(
 						}
 					} else if result != nil {
 						results[i] = ingestionResult{
-							docRef:        ssau.docRef,
-							documentName:  result.DocumentName,
-							componentName: result.ComponentName,
-							status:        result.StatusMeta.Status,
-							userMessage:   result.StatusMeta.UserMessage,
+							docRef:       ssau.docRef,
+							documentName: result.DocumentName,
+							status:       result.StatusMeta.Status,
+							userMessage:  result.StatusMeta.UserMessage,
 						}
 					}
 					resultsMutex.Unlock()
@@ -402,8 +394,8 @@ func Upload(
 			// Display results in a table
 			fmt.Fprintf(os.Stderr, "\nIngestion Results:\n")
 			w := tabwriter.NewWriter(os.Stderr, 0, 0, 2, ' ', 0)
-			_, _ = fmt.Fprintln(w, "STATUS\tDOCUMENT NAME\tCOMPONENT NAME\tDOCUMENT REF\tMESSAGE")
-			_, _ = fmt.Fprintln(w, "------\t-------------\t--------------\t------------\t-------")
+			_, _ = fmt.Fprintln(w, "STATUS\tDOCUMENT NAME\tDOCUMENT REF\tMESSAGE")
+			_, _ = fmt.Fprintln(w, "------\t-------------\t------------\t-------")
 			for _, r := range results {
 				statusSymbol := "✓"
 				if r.status == "failed" || r.err != nil {
@@ -413,10 +405,6 @@ func Upload(
 				if docName == "" {
 					docName = "-"
 				}
-				compName := r.componentName
-				if compName == "" {
-					compName = "-"
-				}
 				message := r.userMessage
 				if r.err != nil {
 					message = r.err.Error()
@@ -424,7 +412,7 @@ func Upload(
 				if message == "" {
 					message = "-"
 				}
-				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", statusSymbol, docName, compName, r.docRef, message)
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", statusSymbol, docName, r.docRef, message)
 			}
 			_ = w.Flush()
 		}

--- a/pkg/repo/uploader_test.go
+++ b/pkg/repo/uploader_test.go
@@ -739,7 +739,6 @@ func TestUploadMetadata(t *testing.T) {
 		tag                        string
 		softwareID                 string
 		sbomSubject                string
-		componentName              string
 		sbomSubjectNameOverride    string
 		sbomSubjectVersionOverride string
 		forge                      string
@@ -773,18 +772,16 @@ func TestUploadMetadata(t *testing.T) {
 			},
 		},
 		{
-			name:          "combined with existing fields",
-			alias:         "my-alias",
-			componentName: "my-component",
-			forge:         "github.com",
-			org:           "testorg",
-			repo:          "testrepo",
+			name:  "combined with existing fields",
+			alias: "my-alias",
+			forge: "github.com",
+			org:   "testorg",
+			repo:  "testrepo",
 			expectedMeta: map[string]string{
-				"alias":          "my-alias",
-				"component_name": "my-component",
-				"forge":          "github.com",
-				"org":            "testorg",
-				"repo":           "testrepo",
+				"alias": "my-alias",
+				"forge": "github.com",
+				"org":   "testorg",
+				"repo":  "testrepo",
 			},
 		},
 		{
@@ -794,7 +791,6 @@ func TestUploadMetadata(t *testing.T) {
 			tag:                        "v1.0",
 			softwareID:                 "12345",
 			sbomSubject:                "subject",
-			componentName:              "component",
 			sbomSubjectNameOverride:    "name-override",
 			sbomSubjectVersionOverride: "version-override",
 			forge:                      "github.com",
@@ -808,7 +804,6 @@ func TestUploadMetadata(t *testing.T) {
 				"tag":                           "v1.0",
 				"software_id":                   "12345",
 				"sbom_subject":                  "subject",
-				"component_name":                "component",
 				"sbom_subject_name_override":    "name-override",
 				"sbom_subject_version_override": "version-override",
 				"forge":                         "github.com",
@@ -846,9 +841,6 @@ func TestUploadMetadata(t *testing.T) {
 			}
 			if tt.sbomSubject != "" {
 				uploadMeta["sbom_subject"] = tt.sbomSubject
-			}
-			if tt.componentName != "" {
-				uploadMeta["component_name"] = tt.componentName
 			}
 			if tt.sbomSubjectNameOverride != "" {
 				uploadMeta["sbom_subject_name_override"] = tt.sbomSubjectNameOverride
@@ -957,7 +949,6 @@ func TestUpload_ValidationErrors(t *testing.T) {
 				tt.tag,
 				tt.softwareID,
 				tt.sbomSubject,
-				"",
 				"",
 				"",
 				false,


### PR DESCRIPTION
- Drop `--component-name` from `kusari platform upload`: removed from the `Upload` signature, upload metadata, and the ingestion-status table/struct. The flag stays registered and is `MarkDeprecated` so existing CLI callers get a cobra warning pointing to https://docs.us.kusari.cloud/software/components instead of an unknown-flag error. Config-file/env-var callers are warned in `RunE` (gated on `!Flags().Changed(...)` to avoid double-warning CLI users).
- Drop the unused `SBOMComponentName` field from `configuration.Config`, including its default, test assertions, and the `sbom_component_name` line in the SBOM testdata fixture.