### PR TITLE
Update module path to /v2 for major version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Command line interface for Kusari.
 
 1. Have [Go installed](https://go.dev/doc/install).
 
-1. `go install github.com/kusaridev/kusari-cli/kusari@latest`
+1. `go install github.com/kusaridev/kusari-cli/v2/kusari@latest`
 
 Alternatively, you can install pre-built binaries for supported platforms from
 the [GitHub releases page](https://github.com/kusaridev/kusari-cli/releases).

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kusaridev/kusari-cli
+module github.com/kusaridev/kusari-cli/v2
 
 go 1.25.9
 

--- a/kusari/cmd/ai_install.go
+++ b/kusari/cmd/ai_install.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/huh"
-	"github.com/kusaridev/kusari-cli/pkg/mcpinstall"
+	"github.com/kusaridev/kusari-cli/v2/pkg/mcpinstall"
 	"github.com/spf13/cobra"
 )
 

--- a/kusari/cmd/ai_list.go
+++ b/kusari/cmd/ai_list.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kusaridev/kusari-cli/pkg/mcpinstall"
+	"github.com/kusaridev/kusari-cli/v2/pkg/mcpinstall"
 	"github.com/spf13/cobra"
 )
 

--- a/kusari/cmd/ai_serve.go
+++ b/kusari/cmd/ai_serve.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kusaridev/kusari-cli/pkg/ai"
+	"github.com/kusaridev/kusari-cli/v2/pkg/ai"
 	"github.com/spf13/cobra"
 )
 

--- a/kusari/cmd/ai_uninstall.go
+++ b/kusari/cmd/ai_uninstall.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/huh"
-	"github.com/kusaridev/kusari-cli/pkg/mcpinstall"
+	"github.com/kusaridev/kusari-cli/v2/pkg/mcpinstall"
 	"github.com/spf13/cobra"
 )
 

--- a/kusari/cmd/auth_login.go
+++ b/kusari/cmd/auth_login.go
@@ -6,8 +6,8 @@ package cmd
 import (
 	"fmt"
 
-	l "github.com/kusaridev/kusari-cli/pkg/login"
-	"github.com/kusaridev/kusari-cli/pkg/port"
+	l "github.com/kusaridev/kusari-cli/v2/pkg/login"
+	"github.com/kusaridev/kusari-cli/v2/pkg/port"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/kusari/cmd/auth_select_tenant.go
+++ b/kusari/cmd/auth_select_tenant.go
@@ -6,8 +6,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/kusaridev/kusari-cli/pkg/auth"
-	l "github.com/kusaridev/kusari-cli/pkg/login"
+	"github.com/kusaridev/kusari-cli/v2/pkg/auth"
+	l "github.com/kusaridev/kusari-cli/v2/pkg/login"
 	"github.com/spf13/cobra"
 )
 

--- a/kusari/cmd/auth_select_workspace.go
+++ b/kusari/cmd/auth_select_workspace.go
@@ -6,8 +6,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/kusaridev/kusari-cli/pkg/auth"
-	l "github.com/kusaridev/kusari-cli/pkg/login"
+	"github.com/kusaridev/kusari-cli/v2/pkg/auth"
+	l "github.com/kusaridev/kusari-cli/v2/pkg/login"
 	"github.com/spf13/cobra"
 )
 

--- a/kusari/cmd/configuration_generate_config.go
+++ b/kusari/cmd/configuration_generate_config.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/kusaridev/kusari-cli/pkg/configuration"
+	"github.com/kusaridev/kusari-cli/v2/pkg/configuration"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/kusari/cmd/configuration_update_config.go
+++ b/kusari/cmd/configuration_update_config.go
@@ -6,7 +6,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/kusaridev/kusari-cli/pkg/configuration"
+	"github.com/kusaridev/kusari-cli/v2/pkg/configuration"
 	"github.com/spf13/cobra"
 )
 

--- a/kusari/cmd/pico_packages.go
+++ b/kusari/cmd/pico_packages.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/kusaridev/kusari-cli/pkg/pico"
+	"github.com/kusaridev/kusari-cli/v2/pkg/pico"
 	"github.com/spf13/cobra"
 )
 

--- a/kusari/cmd/pico_software.go
+++ b/kusari/cmd/pico_software.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/kusaridev/kusari-cli/pkg/pico"
+	"github.com/kusaridev/kusari-cli/v2/pkg/pico"
 	"github.com/spf13/cobra"
 )
 

--- a/kusari/cmd/pico_vulnerabilities.go
+++ b/kusari/cmd/pico_vulnerabilities.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/kusaridev/kusari-cli/pkg/pico"
+	"github.com/kusaridev/kusari-cli/v2/pkg/pico"
 	"github.com/spf13/cobra"
 )
 

--- a/kusari/cmd/platform.go
+++ b/kusari/cmd/platform.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kusaridev/kusari-cli/pkg/auth"
+	"github.com/kusaridev/kusari-cli/v2/pkg/auth"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/kusari/cmd/repo_risk_check.go
+++ b/kusari/cmd/repo_risk_check.go
@@ -4,7 +4,7 @@
 package cmd
 
 import (
-	"github.com/kusaridev/kusari-cli/pkg/repo"
+	"github.com/kusaridev/kusari-cli/v2/pkg/repo"
 	"github.com/spf13/cobra"
 )
 

--- a/kusari/cmd/repo_scan.go
+++ b/kusari/cmd/repo_scan.go
@@ -6,7 +6,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/kusaridev/kusari-cli/pkg/repo"
+	"github.com/kusaridev/kusari-cli/v2/pkg/repo"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/kusari/cmd/root.go
+++ b/kusari/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	"runtime/debug"
 	"strings"
 
-	"github.com/kusaridev/kusari-cli/pkg/constants"
+	"github.com/kusaridev/kusari-cli/v2/pkg/constants"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"

--- a/kusari/cmd/upload.go
+++ b/kusari/cmd/upload.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kusaridev/kusari-cli/pkg/repo"
+	"github.com/kusaridev/kusari-cli/v2/pkg/repo"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/kusari/main.go
+++ b/kusari/main.go
@@ -6,7 +6,7 @@ package main
 import (
 	"os"
 
-	"github.com/kusaridev/kusari-cli/kusari/cmd"
+	"github.com/kusaridev/kusari-cli/v2/kusari/cmd"
 )
 
 var (

--- a/pkg/ai/auth.go
+++ b/pkg/ai/auth.go
@@ -9,9 +9,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/kusaridev/kusari-cli/pkg/auth"
-	"github.com/kusaridev/kusari-cli/pkg/login"
-	"github.com/kusaridev/kusari-cli/pkg/port"
+	"github.com/kusaridev/kusari-cli/v2/pkg/auth"
+	"github.com/kusaridev/kusari-cli/v2/pkg/login"
+	"github.com/kusaridev/kusari-cli/v2/pkg/port"
 )
 
 const (

--- a/pkg/ai/config.go
+++ b/pkg/ai/config.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/kusaridev/kusari-cli/pkg/constants"
+	"github.com/kusaridev/kusari-cli/v2/pkg/constants"
 	"gopkg.in/yaml.v3"
 )
 

--- a/pkg/ai/server.go
+++ b/pkg/ai/server.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kusaridev/kusari-cli/pkg/auth"
-	"github.com/kusaridev/kusari-cli/pkg/pico"
+	"github.com/kusaridev/kusari-cli/v2/pkg/auth"
+	"github.com/kusaridev/kusari-cli/v2/pkg/pico"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/pkg/ai/tools.go
+++ b/pkg/ai/tools.go
@@ -14,9 +14,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/kusaridev/kusari-cli/pkg/auth"
-	"github.com/kusaridev/kusari-cli/pkg/pico"
-	"github.com/kusaridev/kusari-cli/pkg/repo"
+	"github.com/kusaridev/kusari-cli/v2/pkg/auth"
+	"github.com/kusaridev/kusari-cli/v2/pkg/pico"
+	"github.com/kusaridev/kusari-cli/v2/pkg/repo"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/pkg/comment/comment.go
+++ b/pkg/comment/comment.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/kusaridev/kusari-cli/api"
+	"github.com/kusaridev/kusari-cli/v2/api"
 )
 
 //go:embed templates/analysisComment.tmpl

--- a/pkg/comment/comment_test.go
+++ b/pkg/comment/comment_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kusaridev/kusari-cli/api"
+	"github.com/kusaridev/kusari-cli/v2/api"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/kusaridev/kusari-cli/api/configuration"
+	"github.com/kusaridev/kusari-cli/v2/api/configuration"
 	"gopkg.in/yaml.v3"
 )
 

--- a/pkg/github/comment.go
+++ b/pkg/github/comment.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kusaridev/kusari-cli/api"
-	"github.com/kusaridev/kusari-cli/pkg/comment"
+	"github.com/kusaridev/kusari-cli/v2/api"
+	"github.com/kusaridev/kusari-cli/v2/pkg/comment"
 )
 
 const (

--- a/pkg/github/comment_test.go
+++ b/pkg/github/comment_test.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kusaridev/kusari-cli/api"
-	"github.com/kusaridev/kusari-cli/pkg/comment"
+	"github.com/kusaridev/kusari-cli/v2/api"
+	"github.com/kusaridev/kusari-cli/v2/pkg/comment"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/gitlab/comment.go
+++ b/pkg/gitlab/comment.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kusaridev/kusari-cli/api"
-	"github.com/kusaridev/kusari-cli/pkg/comment"
+	"github.com/kusaridev/kusari-cli/v2/api"
+	"github.com/kusaridev/kusari-cli/v2/pkg/comment"
 )
 
 const (

--- a/pkg/gitlab/comment_test.go
+++ b/pkg/gitlab/comment_test.go
@@ -9,8 +9,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/kusaridev/kusari-cli/api"
-	"github.com/kusaridev/kusari-cli/pkg/comment"
+	"github.com/kusaridev/kusari-cli/v2/api"
+	"github.com/kusaridev/kusari-cli/v2/pkg/comment"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -12,8 +12,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/kusaridev/kusari-cli/pkg/auth"
-	urlBuilder "github.com/kusaridev/kusari-cli/pkg/url"
+	"github.com/kusaridev/kusari-cli/v2/pkg/auth"
+	urlBuilder "github.com/kusaridev/kusari-cli/v2/pkg/url"
 )
 
 func Login(ctx context.Context, clientId, clientSecret, redirectUrl, authEndpoint, redirectPort, consoleUrl, platformUrl string, verbose bool, useSso bool) error {

--- a/pkg/pico/client.go
+++ b/pkg/pico/client.go
@@ -13,7 +13,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/kusaridev/kusari-cli/pkg/auth"
+	"github.com/kusaridev/kusari-cli/v2/pkg/auth"
 )
 
 // Client handles HTTP requests to the Kusari Pico API.

--- a/pkg/pico/config.go
+++ b/pkg/pico/config.go
@@ -6,7 +6,7 @@ package pico
 import (
 	"fmt"
 
-	"github.com/kusaridev/kusari-cli/pkg/auth"
+	"github.com/kusaridev/kusari-cli/v2/pkg/auth"
 )
 
 const (

--- a/pkg/repo/packager.go
+++ b/pkg/repo/packager.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/kusaridev/kusari-cli/api"
+	"github.com/kusaridev/kusari-cli/v2/api"
 )
 
 // PackageDirectory creates a zip file from a directory

--- a/pkg/repo/scanner.go
+++ b/pkg/repo/scanner.go
@@ -20,13 +20,13 @@ import (
 
 	"github.com/briandowns/spinner"
 	"github.com/charmbracelet/glamour"
-	"github.com/kusaridev/kusari-cli/api"
-	"github.com/kusaridev/kusari-cli/pkg/auth"
-	"github.com/kusaridev/kusari-cli/pkg/github"
-	"github.com/kusaridev/kusari-cli/pkg/gitlab"
-	"github.com/kusaridev/kusari-cli/pkg/login"
-	"github.com/kusaridev/kusari-cli/pkg/sarif"
-	urlBuilder "github.com/kusaridev/kusari-cli/pkg/url"
+	"github.com/kusaridev/kusari-cli/v2/api"
+	"github.com/kusaridev/kusari-cli/v2/pkg/auth"
+	"github.com/kusaridev/kusari-cli/v2/pkg/github"
+	"github.com/kusaridev/kusari-cli/v2/pkg/gitlab"
+	"github.com/kusaridev/kusari-cli/v2/pkg/login"
+	"github.com/kusaridev/kusari-cli/v2/pkg/sarif"
+	urlBuilder "github.com/kusaridev/kusari-cli/v2/pkg/url"
 )
 
 const (

--- a/pkg/repo/scanner_test.go
+++ b/pkg/repo/scanner_test.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kusaridev/kusari-cli/api"
-	"github.com/kusaridev/kusari-cli/pkg/login"
+	"github.com/kusaridev/kusari-cli/v2/api"
+	"github.com/kusaridev/kusari-cli/v2/pkg/login"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/repo/uploader.go
+++ b/pkg/repo/uploader.go
@@ -20,9 +20,9 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/kusaridev/kusari-cli/pkg/auth"
-	"github.com/kusaridev/kusari-cli/pkg/constants"
-	"github.com/kusaridev/kusari-cli/pkg/login"
+	"github.com/kusaridev/kusari-cli/v2/pkg/auth"
+	"github.com/kusaridev/kusari-cli/v2/pkg/constants"
+	"github.com/kusaridev/kusari-cli/v2/pkg/login"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/pkg/sarif/sarif.go
+++ b/pkg/sarif/sarif.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/kusaridev/kusari-cli/api"
+	"github.com/kusaridev/kusari-cli/v2/api"
 )
 
 // SARIF 2.1.0 structures

--- a/pkg/sarif/sarif_test.go
+++ b/pkg/sarif/sarif_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kusaridev/kusari-cli/api"
+	"github.com/kusaridev/kusari-cli/v2/api"
 )
 
 func TestConvertToSARIF(t *testing.T) {

--- a/specs/001-mcp-server/quickstart.md
+++ b/specs/001-mcp-server/quickstart.md
@@ -7,7 +7,7 @@ This guide walks through using the Kusari MCP Server with Claude Code.
 
 ## Prerequisites
 
-- Kusari CLI installed (`go install github.com/kusaridev/kusari-cli/kusari@latest`)
+- Kusari CLI installed (`go install github.com/kusaridev/kusari-cli/v2/kusari@latest`)
 - Claude Code (VS Code extension) installed
 - Kusari account ([sign up at console.kusari.cloud](https://console.kusari.cloud))
 


### PR DESCRIPTION
## Summary
- Updates the Go module path from `github.com/kusaridev/kusari-cli` to `github.com/kusaridev/kusari-cli/v2` to satisfy Go's semantic import versioning rule for v2+ modules
- Rewrites internal imports across 38 `.go` files
- Updates `go install` examples in `README.md` and `specs/001-mcp-server/quickstart.md` to reference `/v2/kusari@latest`

## Why
The `v2.0.0` tag pushed against the previous module path was rejected by `go install` with:
> invalid version: module contains a go.mod file, so module path must match major version ("github.com/kusaridev/kusari-cli/v2")

Without the `/v2` suffix in the module path, no v2+ tag can be installed via the Go toolchain or proxy.

## Follow-up after merge
The existing `v2.0.0` tag on origin points at the pre-fix commit and is unusable. Recommend deleting it from origin and tagging `v2.0.1` on the merge commit (cleaner than force-moving the tag, since the Go module proxy may have cached the broken version).

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./...` — all packages pass
- [x] After merge: tag `v2.0.1` and confirm `go install github.com/kusaridev/kusari-cli/v2/kusari@v2.0.1` works