### PR TITLE
Point MikeBOM repo at kusari-oss

### DIFF
--- a/pkg/mikebom/mikebom.go
+++ b/pkg/mikebom/mikebom.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 // Package mikebom lazy-installs and invokes a pinned version of MikeBOM
-// (https://github.com/kusari-sandbox/mikebom) as a prerequisite of kusari
+// (https://github.com/kusari-oss/mikebom) as a prerequisite of kusari
 // subcommands that need it.
 package mikebom
 

--- a/pkg/mikebom/versions.go
+++ b/pkg/mikebom/versions.go
@@ -7,7 +7,7 @@ package mikebom
 
 const (
 	Version = "0.1.0-alpha.42"
-	Repo    = "kusari-sandbox/mikebom"
+	Repo    = "kusari-oss/mikebom"
 )
 
 // asset names + SHA256 hashes per GOOS/GOARCH, taken from the upstream

--- a/scripts/bump-mikebom.sh
+++ b/scripts/bump-mikebom.sh
@@ -14,7 +14,7 @@ if [[ -z "${TAG}" ]]; then
     exit 2
 fi
 VERSION="${TAG#v}"
-REPO="kusari-sandbox/mikebom"
+REPO="kusari-oss/mikebom"
 OUT="$(cd "$(dirname "$0")/.." && pwd)/pkg/mikebom/versions.go"
 
 SUMS="$(curl -fsSL "https://github.com/${REPO}/releases/download/${TAG}/SHA256SUMS")"


### PR DESCRIPTION
MikeBOM graduated from kusari-sandbox to kusari-oss. Update the release download repo in versions.go and bump-mikebom.sh, plus the doc comment in mikebom.go. Asset names and SHA256 hashes are unchanged.