### PR TITLE
update to add override branch for CI runs

### DIFF
--- a/kusari/cmd/repo_scan.go
+++ b/kusari/cmd/repo_scan.go
@@ -16,6 +16,7 @@ var (
 	outputFormat    string
 	commentPlatform string
 	fullOutput      bool
+	overrideBranch  string
 )
 
 func init() {
@@ -23,12 +24,14 @@ func init() {
 	scancmd.Flags().StringVarP(&outputFormat, "output-format", "", "markdown", "output format (markdown or sarif)")
 	scancmd.Flags().StringVar(&commentPlatform, "comment", "", "post results as a comment to the specified platform's PR/MR (e.g., 'gitlab', 'github')")
 	scancmd.Flags().BoolVar(&fullOutput, "full-output", false, "output full results instead of truncated")
+	scancmd.Flags().StringVar(&overrideBranch, "override-branch", "", "override the detected branch name (useful in CI environments with detached HEAD state)")
 
 	// Bind flags to viper
 	mustBindPFlag("wait", scancmd.Flags().Lookup("wait"))
 	mustBindPFlag("output-format", scancmd.Flags().Lookup("output-format"))
 	mustBindPFlag("comment", scancmd.Flags().Lookup("comment"))
 	mustBindPFlag("full-output", scancmd.Flags().Lookup("full-output"))
+	mustBindPFlag("override-branch", scancmd.Flags().Lookup("override-branch"))
 }
 
 func scan() *cobra.Command {
@@ -43,7 +46,7 @@ func scan() *cobra.Command {
 		dir := args[0]
 		ref := args[1]
 
-		return repo.Scan(dir, ref, platformUrl, consoleUrl, verbose, wait, outputFormat, commentPlatform, fullOutput)
+		return repo.Scan(dir, ref, platformUrl, consoleUrl, verbose, wait, outputFormat, commentPlatform, fullOutput, overrideBranch)
 	}
 
 	return scancmd
@@ -62,5 +65,6 @@ var scancmd = &cobra.Command{
 		outputFormat = viper.GetString("output-format")
 		commentPlatform = viper.GetString("comment")
 		fullOutput = viper.GetBool("full-output")
+		overrideBranch = viper.GetString("override-branch")
 	},
 }

--- a/pkg/ai/tools.go
+++ b/pkg/ai/tools.go
@@ -65,6 +65,7 @@ func (s *Server) executeScanLocalChanges(ctx context.Context, args ScanLocalChan
 			outputFormat,
 			"",   // no comment platform for MCP
 			true, // full output to get complete results in MCP response
+			"",   // no branch override for MCP
 		)
 	})
 

--- a/pkg/auth/storage.go
+++ b/pkg/auth/storage.go
@@ -141,6 +141,7 @@ type WorkspaceInfo struct {
 	PlatformUrl  string `json:"platformUrl"`  // Track which platform this workspace belongs to
 	AuthEndpoint string `json:"authEndpoint"` // Track which auth endpoint this workspace belongs to
 	Tenant       string `json:"tenant"`       // The tenant name (e.g., "demo")
+	IsMachine    bool   `json:"isMachine"`    // True when authenticated with client credentials (API/CI mode)
 }
 
 // getWorkspaceFilePath returns the full path to the workspace file

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -61,6 +61,7 @@ func Login(ctx context.Context, clientId, clientSecret, redirectUrl, authEndpoin
 			PlatformUrl:  platformUrl,
 			AuthEndpoint: currentAuthEndpoint,
 			Tenant:       selectedTenant,
+			IsMachine:    true,
 		}
 		fmt.Printf("Auto-selecting workspace for CI/CD: %s\n", selectedWorkspace.Description)
 		if selectedTenant != "" {

--- a/pkg/repo/packager.go
+++ b/pkg/repo/packager.go
@@ -79,18 +79,24 @@ func packageDirectory(full bool) (int64, error) {
 	return fi.Size(), nil
 }
 
-func createMeta(rev string, full bool) (*api.BundleMeta, error) {
+func createMeta(rev string, full bool, overrideBranch string) (*api.BundleMeta, error) {
 	repoDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get repo directory: %w", err)
 	}
 
-	branch, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
-	if err != nil {
-		return nil, fmt.Errorf("failed to run git rev-parse: %w", err)
-	}
-	if len(branch) == 0 {
-		return nil, fmt.Errorf("git rev-parse command produced no output")
+	var branch []byte
+	if overrideBranch != "" {
+		branch = []byte(overrideBranch)
+	} else {
+		var err error
+		branch, err = exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
+		if err != nil {
+			return nil, fmt.Errorf("failed to run git rev-parse: %w", err)
+		}
+		if len(branch) == 0 {
+			return nil, fmt.Errorf("git rev-parse command produced no output")
+		}
 	}
 
 	remote, err := exec.Command("git", "remote", "get-url", "origin").Output()

--- a/pkg/repo/packager_test.go
+++ b/pkg/repo/packager_test.go
@@ -12,7 +12,73 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestCreateMeta_OverrideBranch(t *testing.T) {
+	tests := []struct {
+		name           string
+		overrideBranch string
+		wantBranch     string // empty means "expect git-detected branch (not HEAD)"
+	}{
+		{
+			name:           "uses override branch when provided",
+			overrideBranch: "feature/my-pr-branch",
+			wantBranch:     "feature/my-pr-branch",
+		},
+		{
+			name:           "uses override branch simulating detached HEAD in CI",
+			overrideBranch: "main",
+			wantBranch:     "main",
+		},
+		{
+			name:           "falls back to git when override is empty",
+			overrideBranch: "",
+			wantBranch:     "", // checked separately: must be non-empty and not "HEAD"
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoDir := t.TempDir()
+			tempDir := t.TempDir()
+
+			originalDir, err := os.Getwd()
+			require.NoError(t, err)
+			defer func() {
+				_ = os.Chdir(originalDir)
+			}()
+
+			require.NoError(t, os.Chdir(repoDir))
+
+			runCmd(t, repoDir, "git", "init")
+			runCmd(t, repoDir, "git", "config", "user.email", "test@example.com")
+			runCmd(t, repoDir, "git", "config", "user.name", "Test User")
+			writeFile(t, filepath.Join(repoDir, "test.txt"), "content")
+			runCmd(t, repoDir, "git", "add", ".")
+			runCmd(t, repoDir, "git", "commit", "-m", "initial commit")
+
+			tarballDir = tempDir
+			workingDir = filepath.Join(tempDir, workingDirName)
+			require.NoError(t, os.Mkdir(workingDir, 0700))
+			metaName = filepath.Join(workingDir, metaFile)
+			patchName = filepath.Join(workingDir, patchFile)
+
+			meta, err := createMeta("HEAD", false, tt.overrideBranch)
+			require.NoError(t, err)
+
+			if tt.wantBranch != "" {
+				assert.Equal(t, tt.wantBranch, meta.CurrentBranch)
+			} else {
+				// git-detected branch: must be non-empty and not "HEAD"
+				assert.NotEmpty(t, meta.CurrentBranch)
+				assert.NotEqual(t, "HEAD", meta.CurrentBranch)
+			}
+		})
+	}
+}
 
 func TestPackageDirectory(t *testing.T) {
 	tests := []struct {

--- a/pkg/repo/scanner.go
+++ b/pkg/repo/scanner.go
@@ -48,14 +48,14 @@ var (
 	workingDir string
 )
 
-func Scan(dir string, rev string, platformUrl string, consoleUrl string, verbose bool, wait bool, outputFormat string, commentPlatform string, fullOutput bool) error {
-	return scan(dir, rev, platformUrl, consoleUrl, verbose, wait, false, outputFormat, commentPlatform, fullOutput, nil)
+func Scan(dir string, rev string, platformUrl string, consoleUrl string, verbose bool, wait bool, outputFormat string, commentPlatform string, fullOutput bool, overrideBranch string) error {
+	return scan(dir, rev, platformUrl, consoleUrl, verbose, wait, false, outputFormat, commentPlatform, fullOutput, overrideBranch, nil)
 }
 
 func RiskCheck(dir string, platformUrl string, consoleUrl string, verbose bool, wait bool) error {
 	// default to outputformat "markdown" for now for risk check as it will link to console
 	// commentPlatform is empty for risk-check as it's not typically run in MR context
-	return scan(dir, "", platformUrl, consoleUrl, verbose, wait, true, "markdown", "", false, nil)
+	return scan(dir, "", platformUrl, consoleUrl, verbose, wait, true, "markdown", "", false, "", nil)
 }
 
 // scanMock facilitates use of mock values for testing
@@ -64,16 +64,18 @@ type scanMock struct {
 	presignedURLGetter     func(apiEndpoint string, jwtToken string, filePath, workspace string, full bool, size int64) (string, error)
 	defaultWorkspaceGetter func(platformUrl string, jwtToken string) ([]login.Workspace, map[string][]string, error)
 	token                  string
+	isMachineAuth          bool
 }
 
 func scan(dir string, rev string, platformUrl string, consoleUrl string, verbose bool, wait bool, full bool, outputFormat string,
-	commentPlatform string, fullOutput bool, mock *scanMock) error {
+	commentPlatform string, fullOutput bool, overrideBranch string, mock *scanMock) error {
 	if verbose {
 		fmt.Fprintf(os.Stderr, " dir: %s\n", dir)
 		fmt.Fprintf(os.Stderr, " rev: %s\n", rev)
 		fmt.Fprintf(os.Stderr, " platformUrl: %s\n", platformUrl)
 		fmt.Fprintf(os.Stderr, " consoleUrl: %s\n", consoleUrl)
 		fmt.Fprintf(os.Stderr, " outputFormat: %s\n", outputFormat)
+		fmt.Fprintf(os.Stderr, " overrideBranch: %s\n", overrideBranch)
 	}
 
 	// Check to see if the directory has a .git directory. If it does not, it is not the root of
@@ -151,6 +153,21 @@ func scan(dir string, rev string, platformUrl string, consoleUrl string, verbose
 		accessToken = token.AccessToken
 	}
 
+	// If authenticated with client credentials (API/CI mode), --override-branch is required
+	// because CI environments typically use detached HEAD state, causing git to report "HEAD"
+	// instead of the actual branch name.
+	isMachine := false
+	if mock == nil {
+		if ws, wsErr := auth.LoadWorkspace(platformUrl, ""); wsErr == nil {
+			isMachine = ws.IsMachine
+		}
+	} else {
+		isMachine = mock.isMachineAuth
+	}
+	if isMachine && overrideBranch == "" {
+		return fmt.Errorf("--override-branch is required when using API key authentication (detached HEAD state in CI would report 'HEAD' as the branch name)")
+	}
+
 	if err := validateDirectory(dir); err != nil {
 		return fmt.Errorf("failed to validate directory: %w", err)
 	}
@@ -186,7 +203,7 @@ func scan(dir string, rev string, platformUrl string, consoleUrl string, verbose
 		cleanupWorkingDirectory(tempDir)
 	}()
 
-	meta, err := createMeta(rev, full)
+	meta, err := createMeta(rev, full, overrideBranch)
 	if err != nil {
 		return fmt.Errorf("failed to create meta file: %w", err)
 	}

--- a/pkg/repo/scanner_test.go
+++ b/pkg/repo/scanner_test.go
@@ -73,7 +73,7 @@ func TestScan_ArchiveFormat(t *testing.T) {
 		}
 
 		// Run the scan with dependencies injection
-		err := scan(testDir, "HEAD", "https://platform.example.com", "https://console.example.com", false, false, full, "markdown", "", false, mock)
+		err := scan(testDir, "HEAD", "https://platform.example.com", "https://console.example.com", false, false, full, "markdown", "", false, "", mock)
 		require.NoError(t, err)
 
 		// Verify upload was called
@@ -82,6 +82,89 @@ func TestScan_ArchiveFormat(t *testing.T) {
 		// Verify the archive format
 		preservedPath := filepath.Join(testDir, preservedArchive)
 		verifyArchiveFormat(t, preservedPath, filepath.Base(testDir), full)
+	}
+}
+
+func TestScan_OverrideBranchValidation(t *testing.T) {
+	tests := []struct {
+		name           string
+		isMachineAuth  bool
+		overrideBranch string
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name:           "machine auth without override branch errors",
+			isMachineAuth:  true,
+			overrideBranch: "",
+			wantErr:        true,
+			errContains:    "--override-branch is required",
+		},
+		{
+			name:           "machine auth with override branch succeeds",
+			isMachineAuth:  true,
+			overrideBranch: "feature/my-pr-branch",
+			wantErr:        false,
+		},
+		{
+			name:           "human auth without override branch succeeds",
+			isMachineAuth:  false,
+			overrideBranch: "",
+			wantErr:        false,
+		},
+		{
+			name:           "human auth with override branch succeeds",
+			isMachineAuth:  false,
+			overrideBranch: "feature/my-pr-branch",
+			wantErr:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDir := t.TempDir()
+
+			require.NoError(t, os.Chdir(testDir))
+			require.NoError(t, runCommand("git", "init"))
+			require.NoError(t, runCommand("git", "config", "user.email", "test@example.com"))
+			require.NoError(t, runCommand("git", "config", "user.name", "Test User"))
+
+			testFile := filepath.Join(testDir, "test.txt")
+			require.NoError(t, os.WriteFile(testFile, []byte("test content"), 0644))
+			require.NoError(t, runCommand("git", "add", "."))
+			require.NoError(t, runCommand("git", "commit", "-m", "initial commit"))
+
+			// Make an uncommitted change so git diff HEAD produces output
+			require.NoError(t, os.WriteFile(testFile, []byte("uncommitted change"), 0644))
+
+			mock := &scanMock{
+				isMachineAuth: tt.isMachineAuth,
+				fileUploader: func(presignedURL, filePath string) error {
+					return nil
+				},
+				presignedURLGetter: func(apiEndpoint string, jwtToken string, filePath, workspace string, full bool, size int64) (string, error) {
+					return "https://example.com/workspace/test-workspace-id/user/human/test-user-id/diff/blob/123", nil
+				},
+				defaultWorkspaceGetter: func(platformUrl string, jwtToken string) ([]login.Workspace, map[string][]string, error) {
+					return []login.Workspace{
+							{ID: "1f961986-c9f3-4760-9d55-1298136cbe2a", Description: "Test Workspace"},
+						}, map[string][]string{
+							"1f961986-c9f3-4760-9d55-1298136cbe2a": {"test-tenant"},
+						}, nil
+				},
+				token: "token",
+			}
+
+			err := scan(testDir, "HEAD", "https://platform.example.com", "https://console.example.com",
+				false, false, false, "markdown", "", false, tt.overrideBranch, mock)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }
 
@@ -475,7 +558,7 @@ func TestMonoRepoCheck_OnlyForRiskCheck(t *testing.T) {
 
 	t.Run("diff scan should succeed on monorepo", func(t *testing.T) {
 		// Diff scan (full=false) should succeed even with monorepo
-		err := scan(testDir, "HEAD", "https://platform.example.com", "https://console.example.com", false, false, false, "markdown", "", false, mock)
+		err := scan(testDir, "HEAD", "https://platform.example.com", "https://console.example.com", false, false, false, "markdown", "", false, "", mock)
 		assert.NoError(t, err, "diff scan should succeed on monorepo")
 	})
 


### PR DESCRIPTION
```
➜  kusari git:(pxp928-update-override-branch) ./kusari repo scan ../ main     --console-url http://console.dev.kusari.cloud/ \
        --platform-url https://platform.api.dev.kusari.cloud/ --override-branch pxp928-update-override-branch
Generating diff...
Packaging directory...
Using workspace: Kusari (Demo tenant)
Uploading package repo...
Upload successful, your scan is processing!
Once completed, you can see results at: http://console.dev.kusari.cloud/workspaces/dcbbd710-acb0-435b-8a5e-0ade6edc74d8/analysis/cli-user%7Cd6663e1b%7Ckusari-cli%7Cpxp928-update-override-branch%7Cc8a5f568-55f8-46ff-8579-d87a90710870%7C1781272543/result
✓ Analysis complete!
You can also view your results here: http://console.dev.kusari.cloud/workspaces/dcbbd710-acb0-435b-8a5e-0ade6edc74d8/analysis/cli-user%7Cd6663e1b%7Ckusari-cli%7Cpxp928-update-override-branch%7Cc8a5f568-55f8-46ff-8579-d87a90710870%7C1781272543/result
```