### PR TITLE
Strip embedded credentials from git remote URL in bundle metadata

### DIFF
--- a/pkg/repo/packager.go
+++ b/pkg/repo/packager.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -79,6 +80,52 @@ func packageDirectory(full bool) (int64, error) {
 	return fi.Size(), nil
 }
 
+// sanitizeRemoteURL strips any embedded credentials from a git remote URL so
+// that CI-injected tokens (gitlab-ci-token, GitHub x-access-token/oauth2/PAT,
+// etc.) never end up in the bundle metadata. Secrets live in the userinfo
+// component (user:pass@host) of a URL, which is handled as follows:
+//   - A password is always a secret, so it is stripped on every scheme.
+//   - A lone username is ambiguous: on http(s) it is frequently the token
+//     itself (e.g. https://<PAT>@github.com), so it is stripped; on other
+//     schemes (ssh, git, ...) it is a login name (e.g. "git") guarded by
+//     key-based auth, not a secret, so it is kept.
+func sanitizeRemoteURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	// scp-style SSH (git@host:path) has no URL scheme and uses key-based auth.
+	if !strings.Contains(raw, "://") {
+		return raw
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		// A value with embedded credentials that won't parse: drop it rather
+		// than risk leaking a token.
+		return ""
+	}
+
+	if u.User == nil {
+		return u.String()
+	}
+
+	switch u.Scheme {
+	case "http", "https":
+		// On http(s) even a lone username is commonly a token itself, so strip
+		// the whole userinfo component.
+		u.User = nil
+	default:
+		// Other schemes use key-based auth; a bare username is a login name,
+		// not a secret. Only the password (if any) needs to be stripped.
+		if _, hasPassword := u.User.Password(); hasPassword {
+			u.User = url.User(u.User.Username())
+		}
+	}
+	return u.String()
+}
+
 func createMeta(rev string, full bool, overrideBranch string) (*api.BundleMeta, error) {
 	repoDir, err := os.Getwd()
 	if err != nil {
@@ -104,6 +151,9 @@ func createMeta(rev string, full bool, overrideBranch string) (*api.BundleMeta, 
 		// Probably just a local git repo
 		remote = []byte{}
 	}
+	// Strip any embedded credentials (e.g. gitlab-ci-token, GitHub
+	// x-access-token / PAT) that CI systems bake into the remote URL.
+	remote = []byte(sanitizeRemoteURL(string(remote)))
 
 	status, err := exec.Command("git", "status", "--porcelain").Output()
 	if err != nil {

--- a/pkg/repo/packager_test.go
+++ b/pkg/repo/packager_test.go
@@ -80,6 +80,96 @@ func TestCreateMeta_OverrideBranch(t *testing.T) {
 	}
 }
 
+func TestSanitizeRemoteURL(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "strips gitlab-ci-token credentials",
+			raw:  "https://gitlab-ci-token:secret-token@gitlab.com/group/project.git",
+			want: "https://gitlab.com/group/project.git",
+		},
+		{
+			name: "strips github x-access-token credentials",
+			raw:  "https://x-access-token:ghp_secret@github.com/owner/repo.git",
+			want: "https://github.com/owner/repo.git",
+		},
+		{
+			name: "strips github oauth2 credentials",
+			raw:  "https://oauth2:secret@github.com/owner/repo.git",
+			want: "https://github.com/owner/repo.git",
+		},
+		{
+			name: "strips user:pat credentials",
+			raw:  "https://user:ghp_secret@github.com/owner/repo.git",
+			want: "https://github.com/owner/repo.git",
+		},
+		{
+			name: "strips username-only userinfo",
+			raw:  "https://token@github.com/owner/repo.git",
+			want: "https://github.com/owner/repo.git",
+		},
+		{
+			name: "leaves clean https URL unchanged",
+			raw:  "https://github.com/owner/repo.git",
+			want: "https://github.com/owner/repo.git",
+		},
+		{
+			name: "leaves scp-style ssh remote unchanged",
+			raw:  "git@github.com:owner/repo.git",
+			want: "git@github.com:owner/repo.git",
+		},
+		{
+			name: "leaves ssh:// URL unchanged (login user, not a secret)",
+			raw:  "ssh://git@github.com/owner/repo.git",
+			want: "ssh://git@github.com/owner/repo.git",
+		},
+		{
+			name: "leaves git:// URL unchanged",
+			raw:  "git://github.com/owner/repo.git",
+			want: "git://github.com/owner/repo.git",
+		},
+		{
+			name: "strips password from ssh:// URL but keeps login user",
+			raw:  "ssh://git:secret@github.com/owner/repo.git",
+			want: "ssh://git@github.com/owner/repo.git",
+		},
+		{
+			name: "strips password from git:// URL but keeps login user",
+			raw:  "git://user:secret@github.com/owner/repo.git",
+			want: "git://user@github.com/owner/repo.git",
+		},
+		{
+			name: "trims surrounding whitespace from git output",
+			raw:  "https://gitlab-ci-token:secret@gitlab.com/group/project.git\n",
+			want: "https://gitlab.com/group/project.git",
+		},
+		{
+			name: "returns empty for empty input",
+			raw:  "",
+			want: "",
+		},
+		{
+			name: "returns empty for whitespace-only input",
+			raw:  "   \n",
+			want: "",
+		},
+		{
+			name: "drops unparseable URL rather than leak it",
+			raw:  "https://gitlab-ci-token:secret@gitlab.com:notaport/project.git",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sanitizeRemoteURL(tt.raw))
+		})
+	}
+}
+
 func TestPackageDirectory(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
CI systems (GitLab CI, GitHub Actions) inject auth tokens into the origin remote URL's userinfo component, e.g.
https://gitlab-ci-token:<token>@gitlab.com/... . These were being written verbatim into the bundle metadata's Remote field.

Add sanitizeRemoteURL to strip secrets from the userinfo component:
  - A password is always stripped, on every scheme.
  - A lone username is stripped on http(s) (where it is commonly a token itself), but kept on ssh/git remotes where it is a login name (e.g. "git") guarded by key-based auth, not a secret.

This covers every provider in one shot rather than matching token names.