### PR TITLE
feat:Return software and component ids, etc. on ingestion

### DIFF
--- a/kusari/cmd/platform_generate.go
+++ b/kusari/cmd/platform_generate.go
@@ -105,6 +105,7 @@ Examples:
 				uploadRepo,
 				uploadSubrepoPath,
 				uploadCommitSha,
+				uploadResultsFile,
 			)
 		},
 	}

--- a/kusari/cmd/upload.go
+++ b/kusari/cmd/upload.go
@@ -30,6 +30,7 @@ var (
 	uploadRepo                       string
 	uploadSubrepoPath                string
 	uploadCommitSha                  string
+	uploadResultsFile                string
 )
 
 // addUploadFlags registers the upload-related flags on a cobra command.
@@ -58,6 +59,7 @@ func addUploadFlags(cmd *cobra.Command, includeFilePath bool) {
 	cmd.Flags().StringVar(&uploadRepo, "repo", "", "Repository name in the forge")
 	cmd.Flags().StringVar(&uploadSubrepoPath, "subrepo-path", "", "Path to subrepo within the repository (e.g., app/frontend)")
 	cmd.Flags().StringVar(&uploadCommitSha, "commit-sha", "", "Commit SHA (from git) (optional, for SBOMs only)")
+	cmd.Flags().StringVar(&uploadResultsFile, "results-file", "", "Write machine-readable JSON results (software and component IDs for each ingested SBOM) to this file (requires --wait)")
 }
 
 // uploadStringVars / uploadBoolVars are the single source of truth for the
@@ -79,6 +81,7 @@ var uploadStringVars = map[string]*string{
 	"repo":                          &uploadRepo,
 	"subrepo-path":                  &uploadSubrepoPath,
 	"commit-sha":                    &uploadCommitSha,
+	"results-file":                  &uploadResultsFile,
 }
 
 var uploadBoolVars = map[string]*bool{
@@ -162,6 +165,7 @@ func upload() *cobra.Command {
 			uploadRepo,
 			uploadSubrepoPath,
 			uploadCommitSha,
+			uploadResultsFile,
 		)
 	}
 

--- a/kusari/cmd/upload_test.go
+++ b/kusari/cmd/upload_test.go
@@ -34,6 +34,7 @@ func TestLoadUploadFromViper(t *testing.T) {
 		"repo":                          "rp",
 		"subrepo-path":                  "srp",
 		"commit-sha":                    "csh",
+		"results-file":                  "rf",
 	}
 	boolExpected := map[string]bool{
 		"openvex":                true,

--- a/pkg/repo/uploader.go
+++ b/pkg/repo/uploader.go
@@ -662,9 +662,13 @@ func checkSBOMsForBlockedPackages(ctx context.Context, client *http.Client, acce
 
 // pollForSoftwareIDs polls the Pico software ID endpoint until the software and
 // SBOM IDs for the given SBOM subject/URI are available (the SBOM has been ingested),
-// or the context is cancelled.
+// or the context is cancelled. A hard 15-minute cap applies even when the caller's
+// context has no deadline.
 func pollForSoftwareIDs(ctx context.Context, client *http.Client, accessToken, tenantEndpoint string, ssau sbomSubjectAndURI) (softwareIDAndSbomID, error) {
 	var ids softwareIDAndSbomID
+
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Minute)
+	defer cancel()
 
 	for {
 		res, err := makePicoRequest(ctx, client, accessToken, tenantEndpoint, fmt.Sprintf("pico/v1/software/id?software_name=%s&sbom_uri=%s",

--- a/pkg/repo/uploader.go
+++ b/pkg/repo/uploader.go
@@ -104,6 +104,29 @@ type softwareComponentInfo struct {
 	ComponentName *string `json:"component_name"`
 }
 
+// sbomResult is one entry in the machine-readable results file. ID fields are
+// null when the lookup failed (see Error) and component fields are null when
+// the software is not mapped to a component. SoftwareName always equals
+// SbomSubject — the SBOM subject is surfaced as "software name" in the
+// frontend, so both names are provided for customer clarity.
+// DO NOT RENAME THESE - CUSTOMERS RELY ON NAMES FOR POST-INGESTION ACTIONS IN CI/CD
+type sbomResult struct {
+	SbomID        *int64  `json:"sbom_id"`
+	SbomSubject   string  `json:"sbom_subject"`
+	SoftwareID    *int64  `json:"software_id"`
+	SoftwareName  string  `json:"software_name"`
+	ComponentID   *int64  `json:"component_id"`
+	ComponentName *string `json:"component_name"`
+	Error         string  `json:"error,omitempty"`
+}
+
+// uploadResults is the envelope written to the --results-file. Wrapped in an
+// object (not a bare array) so more result kinds can be added later without
+// breaking consumers.
+type uploadResults struct {
+	Sboms []sbomResult `json:"sboms"`
+}
+
 type blockedPackages struct {
 	Blocked         bool     `json:"blocked"`
 	BlockedPackages []string `json:"blocked_packages"`
@@ -162,10 +185,15 @@ func Upload(
 	repo string,
 	subrepoPath string,
 	commitSha string,
+	resultsFile string,
 ) error {
 	// Validate required configuration
 	if filePath == "" {
 		return fmt.Errorf("file-path is required")
+	}
+
+	if resultsFile != "" && !wait {
+		return fmt.Errorf("--results-file requires --wait (software IDs are only available after ingestion completes)")
 	}
 
 	if tenantEndpoint == "" {
@@ -324,6 +352,10 @@ func Upload(
 		}
 	}
 
+	// Machine-readable results for the --results-file output, populated after
+	// ingestion completes.
+	var sbomResults []sbomResult
+
 	// Query ingestion status for each uploaded document
 	if wait && workspace != "" && tenantName != "" {
 		type ingestionResult struct {
@@ -434,10 +466,22 @@ func Upload(
 					}
 				}
 				if len(successSSaus) > 0 {
-					reportSoftwareAndComponentIDs(context.Background(), client, accessToken, tenantEndpoint, successSSaus)
+					idResults := lookupSoftwareAndComponentIDs(context.Background(), client, accessToken, tenantEndpoint, successSSaus)
+					printSoftwareAndComponentIDs(idResults)
+					sbomResults = idResults
 				}
 			}
 		}
+	}
+
+	// Write the machine-readable results file. Always written when requested —
+	// even when empty (e.g. no documents ingested successfully) — so pipeline
+	// scripts can rely on the file existing after a successful exit.
+	if resultsFile != "" {
+		if err := writeResultsFile(resultsFile, sbomResults); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "Results written to %s\n", resultsFile)
 	}
 
 	if checkBlockedPackages {
@@ -732,25 +776,17 @@ func getSoftwareComponentInfo(ctx context.Context, client *http.Client, accessTo
 	return info, nil
 }
 
-// reportSoftwareAndComponentIDs looks up the Kusari Platform software ID for each
+// lookupSoftwareAndComponentIDs looks up the Kusari Platform software ID for each
 // ingested SBOM and, when the software is already mapped to a component, the
-// component ID. Results are printed as a table to stdout so they can be captured
-// in CI. Lookup errors are reported per-row and do not fail the upload.
-func reportSoftwareAndComponentIDs(ctx context.Context, client *http.Client, accessToken, tenantEndpoint string, ssaus []sbomSubjectAndURI) {
-	type idReport struct {
-		subject   string
-		ids       softwareIDAndSbomID
-		component softwareComponentInfo
-		err       error
-	}
-
+// component ID. Lookup errors are recorded per-result and do not fail the upload.
+func lookupSoftwareAndComponentIDs(ctx context.Context, client *http.Client, accessToken, tenantEndpoint string, ssaus []sbomSubjectAndURI) []sbomResult {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(5)
 
-	reports := make([]idReport, len(ssaus))
+	results := make([]sbomResult, len(ssaus))
 
 	for i, ssau := range ssaus {
 		if ssau.subject == "" && ssau.uri == "" {
@@ -758,53 +794,83 @@ func reportSoftwareAndComponentIDs(ctx context.Context, client *http.Client, acc
 		}
 
 		g.Go(func() error {
-			report := idReport{subject: ssau.subject}
+			result := sbomResult{SoftwareName: ssau.subject, SbomSubject: ssau.subject}
 
 			ids, err := pollForSoftwareIDs(ctx, client, accessToken, tenantEndpoint, ssau)
 			if err != nil {
-				report.err = err
-				reports[i] = report
+				result.Error = err.Error()
+				results[i] = result
 				return nil // Don't fail the whole group on individual errors
 			}
-			report.ids = ids
+			result.SoftwareID = &ids.SoftwareID
+			result.SbomID = &ids.SbomID
 
 			component, err := getSoftwareComponentInfo(ctx, client, accessToken, tenantEndpoint, ids.SoftwareID)
 			if err != nil {
-				report.err = err
+				result.Error = err.Error()
 			} else {
-				report.component = component
+				result.ComponentID = component.ComponentID
+				result.ComponentName = component.ComponentName
 			}
 
-			reports[i] = report
+			results[i] = result
 			return nil
 		})
 	}
 
-	_ = g.Wait() // Goroutines never return errors; individual errors are in reports
+	_ = g.Wait() // Goroutines never return errors; individual errors are in results
 
+	// Drop entries skipped for having no subject/URI parsed from the document
+	filtered := make([]sbomResult, 0, len(results))
+	for _, r := range results {
+		if r.SbomSubject == "" && r.Error == "" {
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	return filtered
+}
+
+// printSoftwareAndComponentIDs prints the looked-up IDs as a table on stdout.
+func printSoftwareAndComponentIDs(results []sbomResult) {
 	fmt.Printf("\nSoftware Information:\n")
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "SBOM SUBJECT/SOFTWARE NAME\tSOFTWARE ID\tCOMPONENT ID\tCOMPONENT NAME")
 	_, _ = fmt.Fprintln(w, "--------------------------\t-----------\t------------\t--------------")
-	for _, r := range reports {
-		if r.subject == "" && r.err == nil {
-			continue // skipped (no subject/URI parsed from the document)
-		}
-		if r.err != nil {
-			_, _ = fmt.Fprintf(w, "%s\t-\t-\tlookup failed: %v\n", r.subject, r.err)
+	for _, r := range results {
+		if r.Error != "" {
+			_, _ = fmt.Fprintf(w, "%s\t-\t-\tlookup failed: %s\n", r.SbomSubject, r.Error)
 			continue
 		}
 		componentID := "-"
 		componentName := "-"
-		if r.component.ComponentID != nil {
-			componentID = fmt.Sprintf("%d", *r.component.ComponentID)
-			if r.component.ComponentName != nil && *r.component.ComponentName != "" {
-				componentName = *r.component.ComponentName
+		if r.ComponentID != nil {
+			componentID = fmt.Sprintf("%d", *r.ComponentID)
+			if r.ComponentName != nil && *r.ComponentName != "" {
+				componentName = *r.ComponentName
 			}
 		}
-		_, _ = fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", r.subject, r.ids.SoftwareID, componentID, componentName)
+		_, _ = fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", r.SbomSubject, *r.SoftwareID, componentID, componentName)
 	}
 	_ = w.Flush()
+}
+
+// writeResultsFile writes the machine-readable results envelope as JSON to path.
+// Sboms is normalized to an empty slice so consumers always get {"sboms": []}
+// rather than {"sboms": null}.
+func writeResultsFile(path string, results []sbomResult) error {
+	if results == nil {
+		results = []sbomResult{}
+	}
+	data, err := json.MarshalIndent(uploadResults{Sboms: results}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal results: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write results file: %w", err)
+	}
+	return nil
 }
 
 // makePicoRequest makes an HTTP GET request to the Pico API with authentication

--- a/pkg/repo/uploader.go
+++ b/pkg/repo/uploader.go
@@ -96,6 +96,14 @@ type softwareIDAndSbomID struct {
 	SbomID     int64 `json:"sbom_id"`
 }
 
+// softwareComponentInfo holds the component mapping fields from the
+// software detail endpoint. All fields are null when the software has
+// not been assigned to a component.
+type softwareComponentInfo struct {
+	ComponentID   *int64  `json:"component_id"`
+	ComponentName *string `json:"component_name"`
+}
+
 type blockedPackages struct {
 	Blocked         bool     `json:"blocked"`
 	BlockedPackages []string `json:"blocked_packages"`
@@ -415,6 +423,20 @@ func Upload(
 				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", statusSymbol, docName, r.docRef, message)
 			}
 			_ = w.Flush()
+
+			// Report the software ID (and component ID, if the software is already
+			// mapped to a component) for each successfully ingested SBOM.
+			if !isOpenVex {
+				var successSSaus []sbomSubjectAndURI
+				for i, r := range results {
+					if r.status == "success" && r.err == nil {
+						successSSaus = append(successSSaus, validSSaus[i])
+					}
+				}
+				if len(successSSaus) > 0 {
+					reportSoftwareAndComponentIDs(context.Background(), client, accessToken, tenantEndpoint, successSSaus)
+				}
+			}
 		}
 	}
 
@@ -584,34 +606,10 @@ func checkSBOMsForBlockedPackages(ctx context.Context, client *http.Client, acce
 		}
 
 		g.Go(func() error {
-			var ids softwareIDAndSbomID
-
 			// Poll for software/SBOM IDs until available
-			for {
-				res, err := makePicoRequest(ctx, client, accessToken, tenantEndpoint, fmt.Sprintf("pico/v1/software/id?software_name=%s&sbom_uri=%s",
-					url.QueryEscape(ssau.subject), url.QueryEscape(ssau.uri)))
-				if err != nil {
-					return fmt.Errorf("error making request for IDs: %w", err)
-				}
-				defer res.Body.Close() //nolint:errcheck
-
-				if res.StatusCode == 200 {
-					body, err := io.ReadAll(res.Body)
-					if err != nil {
-						return fmt.Errorf("error reading response body for IDs: %w", err)
-					}
-
-					if err := json.Unmarshal(body, &ids); err != nil {
-						return fmt.Errorf("error unmarshaling response body for IDs: %w", err)
-					}
-
-					break
-				} else if res.StatusCode == 404 {
-					fmt.Printf("  Waiting for SBOM to be ingested (subject: %s)...\n", ssau.subject)
-					time.Sleep(time.Second)
-				} else {
-					return fmt.Errorf("unexpected response status code for IDs: %d", res.StatusCode)
-				}
+			ids, err := pollForSoftwareIDs(ctx, client, accessToken, tenantEndpoint, ssau)
+			if err != nil {
+				return err
 			}
 
 			// Check for blocked packages
@@ -660,6 +658,149 @@ func checkSBOMsForBlockedPackages(ctx context.Context, client *http.Client, acce
 	}
 
 	return slices.Contains(blocked, true), nil
+}
+
+// pollForSoftwareIDs polls the Pico software ID endpoint until the software and
+// SBOM IDs for the given SBOM subject/URI are available (the SBOM has been ingested),
+// or the context is cancelled.
+func pollForSoftwareIDs(ctx context.Context, client *http.Client, accessToken, tenantEndpoint string, ssau sbomSubjectAndURI) (softwareIDAndSbomID, error) {
+	var ids softwareIDAndSbomID
+
+	for {
+		res, err := makePicoRequest(ctx, client, accessToken, tenantEndpoint, fmt.Sprintf("pico/v1/software/id?software_name=%s&sbom_uri=%s",
+			url.QueryEscape(ssau.subject), url.QueryEscape(ssau.uri)))
+		if err != nil {
+			return ids, fmt.Errorf("error making request for IDs: %w", err)
+		}
+
+		switch res.StatusCode {
+		case 200:
+			body, err := io.ReadAll(res.Body)
+			res.Body.Close() //nolint:errcheck
+			if err != nil {
+				return ids, fmt.Errorf("error reading response body for IDs: %w", err)
+			}
+
+			if err := json.Unmarshal(body, &ids); err != nil {
+				return ids, fmt.Errorf("error unmarshaling response body for IDs: %w", err)
+			}
+
+			return ids, nil
+		case 404:
+			res.Body.Close() //nolint:errcheck
+			fmt.Printf("  Waiting for SBOM to be ingested (subject: %s)...\n", ssau.subject)
+			select {
+			case <-ctx.Done():
+				return ids, ctx.Err()
+			case <-time.After(time.Second):
+			}
+		default:
+			res.Body.Close() //nolint:errcheck
+			return ids, fmt.Errorf("unexpected response status code for IDs: %d", res.StatusCode)
+		}
+	}
+}
+
+// getSoftwareComponentInfo fetches the software detail endpoint and returns the
+// component mapping fields (null when the software is not assigned to a component).
+func getSoftwareComponentInfo(ctx context.Context, client *http.Client, accessToken, tenantEndpoint string, softwareID int64) (softwareComponentInfo, error) {
+	var info softwareComponentInfo
+
+	res, err := makePicoRequest(ctx, client, accessToken, tenantEndpoint, fmt.Sprintf("pico/v1/software/%d", softwareID))
+	if err != nil {
+		return info, fmt.Errorf("error making request for software details: %w", err)
+	}
+	defer res.Body.Close() //nolint:errcheck
+
+	if res.StatusCode != 200 {
+		return info, fmt.Errorf("unexpected response status code for software details: %d", res.StatusCode)
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return info, fmt.Errorf("error reading response body for software details: %w", err)
+	}
+
+	if err := json.Unmarshal(body, &info); err != nil {
+		return info, fmt.Errorf("error unmarshaling response body for software details: %w", err)
+	}
+
+	return info, nil
+}
+
+// reportSoftwareAndComponentIDs looks up the Kusari Platform software ID for each
+// ingested SBOM and, when the software is already mapped to a component, the
+// component ID. Results are printed as a table to stdout so they can be captured
+// in CI. Lookup errors are reported per-row and do not fail the upload.
+func reportSoftwareAndComponentIDs(ctx context.Context, client *http.Client, accessToken, tenantEndpoint string, ssaus []sbomSubjectAndURI) {
+	type idReport struct {
+		subject   string
+		ids       softwareIDAndSbomID
+		component softwareComponentInfo
+		err       error
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(5)
+
+	reports := make([]idReport, len(ssaus))
+
+	for i, ssau := range ssaus {
+		if ssau.subject == "" && ssau.uri == "" {
+			continue
+		}
+
+		g.Go(func() error {
+			report := idReport{subject: ssau.subject}
+
+			ids, err := pollForSoftwareIDs(ctx, client, accessToken, tenantEndpoint, ssau)
+			if err != nil {
+				report.err = err
+				reports[i] = report
+				return nil // Don't fail the whole group on individual errors
+			}
+			report.ids = ids
+
+			component, err := getSoftwareComponentInfo(ctx, client, accessToken, tenantEndpoint, ids.SoftwareID)
+			if err != nil {
+				report.err = err
+			} else {
+				report.component = component
+			}
+
+			reports[i] = report
+			return nil
+		})
+	}
+
+	_ = g.Wait() // Goroutines never return errors; individual errors are in reports
+
+	fmt.Printf("\nSoftware IDs:\n")
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "SBOM SUBJECT\tSOFTWARE ID\tCOMPONENT ID\tCOMPONENT")
+	_, _ = fmt.Fprintln(w, "------------\t-----------\t------------\t---------")
+	for _, r := range reports {
+		if r.subject == "" && r.err == nil {
+			continue // skipped (no subject/URI parsed from the document)
+		}
+		if r.err != nil {
+			_, _ = fmt.Fprintf(w, "%s\t-\t-\tlookup failed: %v\n", r.subject, r.err)
+			continue
+		}
+		componentID := "-"
+		componentName := "-"
+		if r.component.ComponentID != nil {
+			componentID = fmt.Sprintf("%d", *r.component.ComponentID)
+			if r.component.ComponentName != nil && *r.component.ComponentName != "" {
+				componentName = *r.component.ComponentName
+			}
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", r.subject, r.ids.SoftwareID, componentID, componentName)
+	}
+	_ = w.Flush()
 }
 
 // makePicoRequest makes an HTTP GET request to the Pico API with authentication

--- a/pkg/repo/uploader.go
+++ b/pkg/repo/uploader.go
@@ -782,10 +782,10 @@ func reportSoftwareAndComponentIDs(ctx context.Context, client *http.Client, acc
 
 	_ = g.Wait() // Goroutines never return errors; individual errors are in reports
 
-	fmt.Printf("\nSoftware IDs:\n")
+	fmt.Printf("\nSoftware Information:\n")
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "SBOM SUBJECT\tSOFTWARE ID\tCOMPONENT ID\tCOMPONENT")
-	_, _ = fmt.Fprintln(w, "------------\t-----------\t------------\t---------")
+	_, _ = fmt.Fprintln(w, "SBOM SUBJECT/SOFTWARE NAME\tSOFTWARE ID\tCOMPONENT ID\tCOMPONENT NAME")
+	_, _ = fmt.Fprintln(w, "--------------------------\t-----------\t------------\t--------------")
 	for _, r := range reports {
 		if r.subject == "" && r.err == nil {
 			continue // skipped (no subject/URI parsed from the document)

--- a/pkg/repo/uploader_test.go
+++ b/pkg/repo/uploader_test.go
@@ -729,6 +729,176 @@ type mockResponse struct {
 	body   string
 }
 
+func TestPollForSoftwareIDs(t *testing.T) {
+	tests := []struct {
+		name               string
+		serverStatus       int
+		serverResp         string
+		expectedSoftwareID int64
+		expectedSbomID     int64
+		expectError        bool
+		errorContains      string
+	}{
+		{
+			name:               "IDs available",
+			serverStatus:       http.StatusOK,
+			serverResp:         `{"software_id": 42, "sbom_id": 7}`,
+			expectedSoftwareID: 42,
+			expectedSbomID:     7,
+		},
+		{
+			name:          "server error",
+			serverStatus:  http.StatusInternalServerError,
+			expectError:   true,
+			errorContains: "unexpected response status code",
+		},
+		{
+			name:          "invalid JSON",
+			serverStatus:  http.StatusOK,
+			serverResp:    `not json`,
+			expectError:   true,
+			errorContains: "error unmarshaling",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.Contains(r.URL.Path, "software/id") {
+					t.Errorf("Unexpected path: %s", r.URL.Path)
+				}
+				w.WriteHeader(tt.serverStatus)
+				_, _ = w.Write([]byte(tt.serverResp))
+			}))
+			defer server.Close()
+
+			ids, err := pollForSoftwareIDs(context.Background(), server.Client(), "test-token", server.URL,
+				sbomSubjectAndURI{subject: "my-app", uri: "urn:uuid:12345"})
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error containing '%s', got nil", tt.errorContains)
+				} else if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("Expected error containing '%s', got '%s'", tt.errorContains, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if ids.SoftwareID != tt.expectedSoftwareID {
+				t.Errorf("Expected software ID %d, got %d", tt.expectedSoftwareID, ids.SoftwareID)
+			}
+			if ids.SbomID != tt.expectedSbomID {
+				t.Errorf("Expected SBOM ID %d, got %d", tt.expectedSbomID, ids.SbomID)
+			}
+		})
+	}
+}
+
+func TestPollForSoftwareIDsRetriesOn404(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 2 {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"software_id": 42, "sbom_id": 7}`))
+	}))
+	defer server.Close()
+
+	ids, err := pollForSoftwareIDs(context.Background(), server.Client(), "test-token", server.URL,
+		sbomSubjectAndURI{subject: "my-app", uri: "urn:uuid:12345"})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if attempts != 2 {
+		t.Errorf("Expected 2 attempts, got %d", attempts)
+	}
+	if ids.SoftwareID != 42 {
+		t.Errorf("Expected software ID 42, got %d", ids.SoftwareID)
+	}
+}
+
+func TestGetSoftwareComponentInfo(t *testing.T) {
+	tests := []struct {
+		name                  string
+		serverStatus          int
+		serverResp            string
+		expectedComponentID   *int64
+		expectedComponentName string
+		expectError           bool
+		errorContains         string
+	}{
+		{
+			name:                  "software mapped to component",
+			serverStatus:          http.StatusOK,
+			serverResp:            `{"id": 42, "name": "my-app", "component_id": 9, "component_name": "my-component", "component_display_name": "My Component"}`,
+			expectedComponentID:   int64Ptr(9),
+			expectedComponentName: "my-component",
+		},
+		{
+			name:         "software not mapped to component",
+			serverStatus: http.StatusOK,
+			serverResp:   `{"id": 42, "name": "my-app", "component_id": null, "component_name": null, "component_display_name": null}`,
+		},
+		{
+			name:          "server error",
+			serverStatus:  http.StatusInternalServerError,
+			expectError:   true,
+			errorContains: "unexpected response status code",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.Contains(r.URL.Path, "pico/v1/software/42") {
+					t.Errorf("Unexpected path: %s", r.URL.Path)
+				}
+				w.WriteHeader(tt.serverStatus)
+				_, _ = w.Write([]byte(tt.serverResp))
+			}))
+			defer server.Close()
+
+			info, err := getSoftwareComponentInfo(context.Background(), server.Client(), "test-token", server.URL, 42)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error containing '%s', got nil", tt.errorContains)
+				} else if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("Expected error containing '%s', got '%s'", tt.errorContains, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if tt.expectedComponentID == nil {
+				if info.ComponentID != nil {
+					t.Errorf("Expected nil component ID, got %d", *info.ComponentID)
+				}
+				return
+			}
+			if info.ComponentID == nil {
+				t.Fatalf("Expected component ID %d, got nil", *tt.expectedComponentID)
+			}
+			if *info.ComponentID != *tt.expectedComponentID {
+				t.Errorf("Expected component ID %d, got %d", *tt.expectedComponentID, *info.ComponentID)
+			}
+			if info.ComponentName == nil || *info.ComponentName != tt.expectedComponentName {
+				t.Errorf("Expected component name %q, got %v", tt.expectedComponentName, info.ComponentName)
+			}
+		})
+	}
+}
+
+func int64Ptr(v int64) *int64 {
+	return &v
+}
+
 // I don't think this actually tests anything. We should get rid of it, or extract
 // upload metadata building into a func and test it here.
 func TestUploadMetadata(t *testing.T) {

--- a/pkg/repo/uploader_test.go
+++ b/pkg/repo/uploader_test.go
@@ -899,6 +899,162 @@ func int64Ptr(v int64) *int64 {
 	return &v
 }
 
+func TestLookupSoftwareAndComponentIDs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "software/id"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"software_id": 42, "sbom_id": 7}`))
+		case strings.Contains(r.URL.Path, "pico/v1/software/42"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id": 42, "name": "my-app", "component_id": 9, "component_name": "my-component"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	ssaus := []sbomSubjectAndURI{
+		{subject: "my-app", uri: "urn:uuid:12345"},
+		{subject: "", uri: ""}, // skipped: no subject/URI parsed
+	}
+
+	results := lookupSoftwareAndComponentIDs(context.Background(), server.Client(), "test-token", server.URL, ssaus)
+
+	if len(results) != 1 {
+		t.Fatalf("Expected 1 result (empty ssau skipped), got %d", len(results))
+	}
+	r := results[0]
+	if r.Error != "" {
+		t.Fatalf("Unexpected error in result: %s", r.Error)
+	}
+	if r.SbomSubject != "my-app" {
+		t.Errorf("Expected SBOM subject 'my-app', got %q", r.SbomSubject)
+	}
+	if r.SoftwareName != "my-app" {
+		t.Errorf("Expected software name 'my-app', got %q", r.SoftwareName)
+	}
+	if r.SoftwareID == nil || *r.SoftwareID != 42 {
+		t.Errorf("Expected software ID 42, got %v", r.SoftwareID)
+	}
+	if r.SbomID == nil || *r.SbomID != 7 {
+		t.Errorf("Expected SBOM ID 7, got %v", r.SbomID)
+	}
+	if r.ComponentID == nil || *r.ComponentID != 9 {
+		t.Errorf("Expected component ID 9, got %v", r.ComponentID)
+	}
+	if r.ComponentName == nil || *r.ComponentName != "my-component" {
+		t.Errorf("Expected component name 'my-component', got %v", r.ComponentName)
+	}
+}
+
+func TestWriteResultsFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		results  []sbomResult
+		expected string
+	}{
+		{
+			name: "mapped software",
+			results: []sbomResult{
+				{
+					SoftwareName:  "my-app",
+					SbomSubject:   "my-app",
+					SoftwareID:    int64Ptr(42),
+					SbomID:        int64Ptr(7),
+					ComponentID:   int64Ptr(9),
+					ComponentName: strPtr("my-component"),
+				},
+			},
+			expected: `{
+  "sboms": [
+    {
+      "sbom_id": 7,
+      "sbom_subject": "my-app",
+      "software_id": 42,
+      "software_name": "my-app",
+      "component_id": 9,
+      "component_name": "my-component"
+    }
+  ]
+}
+`,
+		},
+		{
+			name: "unmapped software has null component fields",
+			results: []sbomResult{
+				{
+					SoftwareName: "my-app",
+					SbomSubject:  "my-app",
+					SoftwareID:   int64Ptr(42),
+					SbomID:       int64Ptr(7),
+				},
+			},
+			expected: `{
+  "sboms": [
+    {
+      "sbom_id": 7,
+      "sbom_subject": "my-app",
+      "software_id": 42,
+      "software_name": "my-app",
+      "component_id": null,
+      "component_name": null
+    }
+  ]
+}
+`,
+		},
+		{
+			name:    "nil results normalized to empty array",
+			results: nil,
+			expected: `{
+  "sboms": []
+}
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "results.json")
+			if err := writeResultsFile(path, tt.results); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("Failed to read results file: %v", err)
+			}
+			if string(data) != tt.expected {
+				t.Errorf("Results file mismatch.\nExpected:\n%s\nGot:\n%s", tt.expected, string(data))
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func TestUploadResultsFileRequiresWait(t *testing.T) {
+	err := Upload(
+		"/test/file.json",
+		"https://test.com",
+		"", "", "",
+		false, // isOpenVex
+		"", "", "", "", "",
+		false, // checkBlockedPackages
+		false, // wait
+		"", "", "", "", "",
+		"results.json",
+	)
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "requires --wait") {
+		t.Errorf("Expected error containing 'requires --wait', got '%s'", err.Error())
+	}
+}
+
 // I don't think this actually tests anything. We should get rid of it, or extract
 // upload metadata building into a func and test it here.
 func TestUploadMetadata(t *testing.T) {
@@ -1128,6 +1284,7 @@ func TestUpload_ValidationErrors(t *testing.T) {
 				"", // repo
 				"", // subrepoPath
 				"", // commit sha
+				"", // resultsFile
 			)
 
 			if !tt.expectError {


### PR DESCRIPTION
Allow users to pass in a `--results-file {{file.json}}` flag to the `platform upload` command, which will output a json file with the corresponding platform data for each sbom ingested, like so:

```json
{
   "sboms": [
    {
      "sbom_id": 7,
      "sbom_subject": "my-app",
      "software_id": 42,
      "software_name": "my-app",
      "component_id": 9,
      "component_name": "my-component"
    }
  ]
} 
```

They can then parse that file and pass in the id's to subsequent `curl` or kusari-cli commands to run checks against platform data as needed (like for example, checking if it's assigned to a component and creating a component if not).

Added the data under an `sboms` top level property to make it flexible - if we want to add other kinds of data to this results file on ingestion later we can easily do so under a separate property