### PR TITLE
feat: add component map option to ingest

### DIFF
--- a/kusari/cmd/platform_generate.go
+++ b/kusari/cmd/platform_generate.go
@@ -106,6 +106,7 @@ Examples:
 				uploadSubrepoPath,
 				uploadCommitSha,
 				uploadResultsFile,
+				uploadMapComponents,
 			)
 		},
 	}

--- a/kusari/cmd/upload.go
+++ b/kusari/cmd/upload.go
@@ -42,6 +42,9 @@ func addUploadFlags(cmd *cobra.Command, includeFilePath bool) {
 		cmd.Flags().StringVarP(&uploadFilePath, "file-path", "f", "", "Path to file or directory to upload (required)")
 	}
 	cmd.Flags().StringVarP(&uploadAlias, "alias", "a", "", "Stored in the SBOM's upload metadata; not currently used by the Kusari platform (optional)")
+	if err := cmd.Flags().MarkDeprecated("alias", "it is not used by the Kusari platform and will be removed in a future release"); err != nil {
+		panic(err)
+	}
 	cmd.Flags().StringVarP(&uploadDocumentType, "document-type", "d", "", "Type of the document (image or build) sbom (optional)")
 	cmd.Flags().BoolVar(&uploadOpenVex, "openvex", false, "Indicate that this is an OpenVEX document (optional, only works with files)")
 	cmd.Flags().StringVar(&uploadTag, "tag", "", "Tag value to set in the document wrapper upload meta (optional, e.g. govulncheck)")
@@ -130,13 +133,17 @@ func uploadPreRun(cmd *cobra.Command, _ []string) {
 	loadUploadFromViper()
 }
 
-// warnIfDeprecatedComponentName prints the deprecation message when
-// component-name was sourced from config/env. CLI uses are already
-// warned about by cobra's MarkDeprecated; this covers the gap.
+// warnIfDeprecatedComponentName prints deprecation messages when
+// component-name or alias were sourced from config/env. CLI uses are
+// already warned about by cobra's MarkDeprecated; this covers the gap.
 func warnIfDeprecatedComponentName(cmd *cobra.Command) {
 	if uploadComponentName != "" && !cmd.Flags().Changed("component-name") {
 		fmt.Fprintln(os.Stderr, "The component-name config value is no longer supported. "+
 			"See https://docs.us.kusari.cloud/software/components for info on how to assign and use Components.")
+	}
+	if uploadAlias != "" && !cmd.Flags().Changed("alias") {
+		fmt.Fprintln(os.Stderr, "The alias config value is deprecated: it is not used by the Kusari platform "+
+			"and will be removed in a future release.")
 	}
 }
 

--- a/kusari/cmd/upload.go
+++ b/kusari/cmd/upload.go
@@ -41,7 +41,7 @@ func addUploadFlags(cmd *cobra.Command, includeFilePath bool) {
 	if includeFilePath {
 		cmd.Flags().StringVarP(&uploadFilePath, "file-path", "f", "", "Path to file or directory to upload (required)")
 	}
-	cmd.Flags().StringVarP(&uploadAlias, "alias", "a", "", "Alias that supersedes the subject in Kusari platform (optional)")
+	cmd.Flags().StringVarP(&uploadAlias, "alias", "a", "", "Stored in the SBOM's upload metadata; not currently used by the Kusari platform (optional)")
 	cmd.Flags().StringVarP(&uploadDocumentType, "document-type", "d", "", "Type of the document (image or build) sbom (optional)")
 	cmd.Flags().BoolVar(&uploadOpenVex, "openvex", false, "Indicate that this is an OpenVEX document (optional, only works with files)")
 	cmd.Flags().StringVar(&uploadTag, "tag", "", "Tag value to set in the document wrapper upload meta (optional, e.g. govulncheck)")

--- a/kusari/cmd/upload.go
+++ b/kusari/cmd/upload.go
@@ -31,6 +31,7 @@ var (
 	uploadSubrepoPath                string
 	uploadCommitSha                  string
 	uploadResultsFile                string
+	uploadMapComponents              bool
 )
 
 // addUploadFlags registers the upload-related flags on a cobra command.
@@ -60,6 +61,7 @@ func addUploadFlags(cmd *cobra.Command, includeFilePath bool) {
 	cmd.Flags().StringVar(&uploadSubrepoPath, "subrepo-path", "", "Path to subrepo within the repository (e.g., app/frontend)")
 	cmd.Flags().StringVar(&uploadCommitSha, "commit-sha", "", "Commit SHA (from git) (optional, for SBOMs only)")
 	cmd.Flags().StringVar(&uploadResultsFile, "results-file", "", "Write machine-readable JSON results (software and component IDs for each ingested SBOM) to this file (requires --wait)")
+	cmd.Flags().BoolVar(&uploadMapComponents, "map-components", false, "After ingestion, ensure each ingested software is mapped to a component: create (or reuse) a component named after the software and assign the software to it (requires --wait)")
 }
 
 // uploadStringVars / uploadBoolVars are the single source of truth for the
@@ -88,6 +90,7 @@ var uploadBoolVars = map[string]*bool{
 	"openvex":                &uploadOpenVex,
 	"check-blocked-packages": &uploadCheckBlocked,
 	"wait":                   &uploadWait,
+	"map-components":         &uploadMapComponents,
 }
 
 // bindUploadFlagsToViper points viper at the upload-related flags on the
@@ -166,6 +169,7 @@ func upload() *cobra.Command {
 			uploadSubrepoPath,
 			uploadCommitSha,
 			uploadResultsFile,
+			uploadMapComponents,
 		)
 	}
 
@@ -199,6 +203,10 @@ Examples:
   # CI/CD: Upload with repository traceability metadata
   kusari platform upload --file-path sbom.json --tenant demo \
     --forge github.com --org myorg --repo myrepo --subrepo-path app/frontend
+
+  # CI/CD: Upload, capture results, and auto-map software to components
+  kusari platform upload --file-path sbom.json --tenant demo \
+    --results-file results.json --map-components
 
   # Dev/Testing: Upload using full tenant endpoint (overrides --tenant)
   kusari platform upload --file-path sbom.json --tenant-endpoint https://demo.api.dev.kusari.cloud`,

--- a/kusari/cmd/upload_test.go
+++ b/kusari/cmd/upload_test.go
@@ -40,6 +40,7 @@ func TestLoadUploadFromViper(t *testing.T) {
 		"openvex":                true,
 		"check-blocked-packages": true,
 		"wait":                   true,
+		"map-components":         true,
 	}
 
 	for k, v := range stringExpected {

--- a/pkg/repo/component_mapper.go
+++ b/pkg/repo/component_mapper.go
@@ -1,0 +1,236 @@
+// Copyright (c) Kusari <https://www.kusari.dev/>
+// SPDX-License-Identifier: MIT
+
+package repo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+// picoReason is the structured error body pico returns on 4xx responses.
+type picoReason struct {
+	Reason string `json:"reason"`
+}
+
+type componentIDAndName struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+type componentsListPage struct {
+	Components []componentIDAndName `json:"components"`
+}
+
+// mapSoftwareToComponents ensures every successfully ingested software in
+// results is assigned to a component. For each entry with a software ID but
+// no component:
+//
+//  1. Create a component named after the software; if that name already
+//     exists, reuse the existing component's ID.
+//  2. Assign the software to it. If pico rejects the assignment because the
+//     component already has a source software, create a fresh component named
+//     "<software-name>-<suffix>" — the suffix is a short prefix of the
+//     ingested document's content hash (docRef) — and assign to that instead.
+//  3. Verify the mapping via the software detail endpoint and record the
+//     final component ID/name back into the results entry, so the results
+//     file reflects the post-mapping state.
+//
+// Entries with a lookup error or an existing component mapping are skipped.
+// The first hard failure aborts and is returned; the results slice keeps any
+// mappings completed before it.
+func mapSoftwareToComponents(ctx context.Context, client *http.Client, accessToken, tenantEndpoint string, results []sbomResult) error {
+	for i := range results {
+		r := &results[i]
+		if r.Error != "" {
+			fmt.Fprintf(os.Stderr, "skipping %q: lookup failed: %s\n", r.SbomSubject, r.Error)
+			continue
+		}
+		if r.SoftwareID == nil {
+			fmt.Fprintf(os.Stderr, "skipping %q: no software ID\n", r.SbomSubject)
+			continue
+		}
+		if r.ComponentID != nil {
+			fmt.Fprintf(os.Stderr, "%s (software %d) already mapped to component %d - nothing to do\n", r.SoftwareName, *r.SoftwareID, *r.ComponentID)
+			continue
+		}
+
+		fmt.Fprintf(os.Stderr, "%s (software %d) is unmapped - creating/locating component\n", r.SoftwareName, *r.SoftwareID)
+		compID, err := ensureComponent(ctx, client, accessToken, tenantEndpoint, r.SoftwareName)
+		if err != nil {
+			return fmt.Errorf("mapping software %d (%s): %w", *r.SoftwareID, r.SoftwareName, err)
+		}
+
+		conflict, err := assignSoftwareToComponent(ctx, client, accessToken, tenantEndpoint, compID, *r.SoftwareID)
+		if err != nil {
+			return fmt.Errorf("mapping software %d (%s): %w", *r.SoftwareID, r.SoftwareName, err)
+		}
+		if conflict {
+			// The reused component already sources a different software; mint
+			// a fresh component with a content-hash suffix instead.
+			freshName := fmt.Sprintf("%s-%s", r.SoftwareName, fallbackSuffix(*r))
+			fmt.Fprintf(os.Stderr, "component %d already has a source software - creating fallback component %s\n", compID, freshName)
+			compID, err = ensureComponent(ctx, client, accessToken, tenantEndpoint, freshName)
+			if err != nil {
+				return fmt.Errorf("mapping software %d (%s): %w", *r.SoftwareID, r.SoftwareName, err)
+			}
+			conflict, err = assignSoftwareToComponent(ctx, client, accessToken, tenantEndpoint, compID, *r.SoftwareID)
+			if err != nil {
+				return fmt.Errorf("mapping software %d (%s): %w", *r.SoftwareID, r.SoftwareName, err)
+			}
+			if conflict {
+				return fmt.Errorf("mapping software %d (%s): fallback component %q already has a source software", *r.SoftwareID, r.SoftwareName, freshName)
+			}
+		}
+
+		// Verify via the software detail endpoint and record the final
+		// mapping from the authoritative response.
+		info, err := getSoftwareComponentInfo(ctx, client, accessToken, tenantEndpoint, *r.SoftwareID)
+		if err != nil {
+			return fmt.Errorf("verifying mapping for software %d (%s): %w", *r.SoftwareID, r.SoftwareName, err)
+		}
+		if info.ComponentID == nil || *info.ComponentID != compID {
+			got := "null"
+			if info.ComponentID != nil {
+				got = fmt.Sprintf("%d", *info.ComponentID)
+			}
+			return fmt.Errorf("verification failed for software %d (%s): component_id=%s, expected %d", *r.SoftwareID, r.SoftwareName, got, compID)
+		}
+		r.ComponentID = info.ComponentID
+		r.ComponentName = info.ComponentName
+		name := ""
+		if info.ComponentName != nil {
+			name = *info.ComponentName
+		}
+		fmt.Fprintf(os.Stderr, "verified: software %d (%s) mapped to component %d (%s)\n", *r.SoftwareID, r.SoftwareName, compID, name)
+	}
+	return nil
+}
+
+// fallbackSuffix derives the fallback component-name suffix for a results
+// entry: a short prefix of the ingested document's sha256 (from docRef),
+// falling back to the SBOM ID when the docRef is absent or malformed.
+func fallbackSuffix(r sbomResult) string {
+	if h, ok := strings.CutPrefix(r.docRef, "sha256_"); ok && len(h) >= 7 {
+		return h[:7]
+	}
+	if r.SbomID != nil {
+		return fmt.Sprintf("%d", *r.SbomID)
+	}
+	return "unmapped"
+}
+
+// ensureComponent creates a component with the given name and returns its ID.
+// If pico reports the name already exists, the existing component's ID is
+// looked up and returned instead.
+func ensureComponent(ctx context.Context, client *http.Client, accessToken, tenantEndpoint, name string) (int64, error) {
+	status, body, err := makePicoJSONRequest(ctx, client, accessToken, tenantEndpoint, http.MethodPost, "pico/v1/components", map[string]any{"name": name})
+	if err != nil {
+		return 0, fmt.Errorf("creating component %q: %w", name, err)
+	}
+	if status < 300 {
+		var comp componentIDAndName
+		if err := json.Unmarshal(body, &comp); err != nil {
+			return 0, fmt.Errorf("decoding create response for component %q: %w", name, err)
+		}
+		return comp.ID, nil
+	}
+	if status == http.StatusBadRequest && strings.Contains(reasonOf(body), "already exists") {
+		return findComponentByName(ctx, client, accessToken, tenantEndpoint, name)
+	}
+	return 0, fmt.Errorf("creating component %q: unexpected status %d: %s", name, status, string(body))
+}
+
+// findComponentByName looks up a component's ID by exact name match.
+func findComponentByName(ctx context.Context, client *http.Client, accessToken, tenantEndpoint, name string) (int64, error) {
+	query := url.Values{"search": {name}, "size": {"1000"}}
+	status, body, err := makePicoJSONRequest(ctx, client, accessToken, tenantEndpoint, http.MethodGet, "pico/v1/components?"+query.Encode(), nil)
+	if err != nil {
+		return 0, fmt.Errorf("listing components searching for %q: %w", name, err)
+	}
+	if status >= 300 {
+		return 0, fmt.Errorf("listing components searching for %q: unexpected status %d: %s", name, status, string(body))
+	}
+	var page componentsListPage
+	if err := json.Unmarshal(body, &page); err != nil {
+		return 0, fmt.Errorf("decoding component list for %q: %w", name, err)
+	}
+	for _, c := range page.Components {
+		if c.Name == name {
+			return c.ID, nil
+		}
+	}
+	return 0, fmt.Errorf("component %q reported as existing but not found via list", name)
+}
+
+// assignSoftwareToComponent assigns the software to the component. Returns
+// conflict=true when pico rejects because the component already has a source
+// software (the caller then falls back to a fresh component).
+func assignSoftwareToComponent(ctx context.Context, client *http.Client, accessToken, tenantEndpoint string, compID, softwareID int64) (bool, error) {
+	path := fmt.Sprintf("pico/v1/components/%d/software", compID)
+	status, body, err := makePicoJSONRequest(ctx, client, accessToken, tenantEndpoint, http.MethodPost, path, map[string]any{"software_ids": []int64{softwareID}})
+	if err != nil {
+		return false, fmt.Errorf("assigning software %d to component %d: %w", softwareID, compID, err)
+	}
+	if status < 300 {
+		return false, nil
+	}
+	if status == http.StatusBadRequest && strings.Contains(reasonOf(body), "already has a source software") {
+		return true, nil
+	}
+	return false, fmt.Errorf("assigning software %d to component %d: unexpected status %d: %s", softwareID, compID, status, string(body))
+}
+
+// reasonOf extracts the structured "reason" field from a pico 4xx body.
+// Returns the empty string when the body isn't the expected shape.
+func reasonOf(body []byte) string {
+	var r picoReason
+	if err := json.Unmarshal(body, &r); err != nil {
+		return ""
+	}
+	return r.Reason
+}
+
+// makePicoJSONRequest makes an authenticated request with an optional JSON
+// body and returns the response status and body. Unlike makePicoRequest it
+// supports non-GET methods and does not treat 4xx as a transport error —
+// callers inspect the status to detect structured pico rejections.
+func makePicoJSONRequest(ctx context.Context, client *http.Client, accessToken, tenantURL, method, pathAndQS string, body any) (int, []byte, error) {
+	var reqBody io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return 0, nil, fmt.Errorf("marshaling request body: %w", err)
+		}
+		reqBody = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, fmt.Sprintf("%s/%s", tenantURL, pathAndQS), reqBody)
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer res.Body.Close() //nolint:errcheck
+
+	respBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return 0, nil, fmt.Errorf("reading response body: %w", err)
+	}
+	return res.StatusCode, respBody, nil
+}

--- a/pkg/repo/component_mapper_test.go
+++ b/pkg/repo/component_mapper_test.go
@@ -1,0 +1,293 @@
+// Copyright (c) Kusari <https://www.kusari.dev/>
+// SPDX-License-Identifier: MIT
+
+package repo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// mockPico is an in-memory pico API for exercising mapSoftwareToComponents:
+// component create (with duplicate-name rejection), list search, software
+// assignment (with source-software conflict), and the software detail
+// endpoint used for verification.
+type mockPico struct {
+	mu         sync.Mutex
+	nextID     int64
+	components map[string]int64 // name -> id
+	sources    map[int64]int64  // component id -> source software id
+	swToComp   map[int64]int64  // software id -> component id
+	failAll    bool
+}
+
+func newMockPico() *mockPico {
+	return &mockPico{
+		nextID:     100,
+		components: map[string]int64{},
+		sources:    map[int64]int64{},
+		swToComp:   map[int64]int64{},
+	}
+}
+
+// seed adds a component and optionally marks it as already sourcing a software.
+func (m *mockPico) seed(name string, sourceSoftware int64) int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	id := m.nextID
+	m.nextID++
+	m.components[name] = id
+	if sourceSoftware != 0 {
+		m.sources[id] = sourceSoftware
+		m.swToComp[sourceSoftware] = id
+	}
+	return id
+}
+
+func (m *mockPico) nameOf(id int64) string {
+	for n, i := range m.components {
+		if i == id {
+			return n
+		}
+	}
+	return ""
+}
+
+func (m *mockPico) handler() http.Handler {
+	writeJSON := func(w http.ResponseWriter, status int, v any) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(v)
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		if m.failAll {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"reason": "boom"})
+			return
+		}
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/pico/v1/components":
+			var body struct {
+				Name string `json:"name"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if _, exists := m.components[body.Name]; exists {
+				writeJSON(w, http.StatusBadRequest, picoReason{Reason: fmt.Sprintf("component with name %q already exists", body.Name)})
+				return
+			}
+			id := m.nextID
+			m.nextID++
+			m.components[body.Name] = id
+			writeJSON(w, http.StatusCreated, componentIDAndName{ID: id, Name: body.Name})
+
+		case r.Method == http.MethodGet && r.URL.Path == "/pico/v1/components":
+			search := r.URL.Query().Get("search")
+			page := componentsListPage{Components: []componentIDAndName{}}
+			for name, id := range m.components {
+				if search == "" || strings.Contains(name, search) {
+					page.Components = append(page.Components, componentIDAndName{ID: id, Name: name})
+				}
+			}
+			writeJSON(w, http.StatusOK, page)
+
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/pico/v1/components/") && strings.HasSuffix(r.URL.Path, "/software"):
+			var compID int64
+			_, _ = fmt.Sscanf(r.URL.Path, "/pico/v1/components/%d/software", &compID)
+			var body struct {
+				SoftwareIDs []int64 `json:"software_ids"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if src, ok := m.sources[compID]; ok && (len(body.SoftwareIDs) != 1 || src != body.SoftwareIDs[0]) {
+				writeJSON(w, http.StatusBadRequest, picoReason{Reason: "component already has a source software"})
+				return
+			}
+			for _, sw := range body.SoftwareIDs {
+				m.sources[compID] = sw
+				m.swToComp[sw] = compID
+			}
+			w.WriteHeader(http.StatusNoContent)
+
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/pico/v1/software/"):
+			var swID int64
+			_, _ = fmt.Sscanf(r.URL.Path, "/pico/v1/software/%d", &swID)
+			info := softwareComponentInfo{}
+			if compID, ok := m.swToComp[swID]; ok {
+				name := m.nameOf(compID)
+				info.ComponentID = &compID
+				info.ComponentName = &name
+			}
+			writeJSON(w, http.StatusOK, info)
+
+		default:
+			writeJSON(w, http.StatusNotFound, picoReason{Reason: "unhandled: " + r.Method + " " + r.URL.Path})
+		}
+	})
+}
+
+func i64Ptr(v int64) *int64 {
+	return &v
+}
+
+func TestMapSoftwareToComponents(t *testing.T) {
+	docRef := "sha256_abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+	t.Run("clean map creates component and writes back", func(t *testing.T) {
+		mock := newMockPico()
+		server := httptest.NewServer(mock.handler())
+		defer server.Close()
+
+		results := []sbomResult{
+			{SbomID: i64Ptr(1), SbomSubject: "cleanapp", SoftwareID: i64Ptr(30), SoftwareName: "cleanapp", docRef: docRef},
+		}
+		if err := mapSoftwareToComponents(context.Background(), server.Client(), "token", server.URL, results); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if results[0].ComponentID == nil {
+			t.Fatal("expected component_id to be written back")
+		}
+		if results[0].ComponentName == nil || *results[0].ComponentName != "cleanapp" {
+			t.Errorf("expected component_name 'cleanapp', got %v", results[0].ComponentName)
+		}
+		if got := mock.componentOf(30); got != *results[0].ComponentID {
+			t.Errorf("mock has software 30 in component %d, results say %d", got, *results[0].ComponentID)
+		}
+	})
+
+	t.Run("already-mapped entry untouched", func(t *testing.T) {
+		mock := newMockPico()
+		server := httptest.NewServer(mock.handler())
+		defer server.Close()
+
+		name := "already"
+		results := []sbomResult{
+			{SbomID: i64Ptr(1), SbomSubject: "already", SoftwareID: i64Ptr(10), SoftwareName: "already", ComponentID: i64Ptr(55), ComponentName: &name, docRef: docRef},
+		}
+		if err := mapSoftwareToComponents(context.Background(), server.Client(), "token", server.URL, results); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if *results[0].ComponentID != 55 {
+			t.Errorf("expected component_id 55 untouched, got %d", *results[0].ComponentID)
+		}
+	})
+
+	t.Run("error entry skipped", func(t *testing.T) {
+		mock := newMockPico()
+		server := httptest.NewServer(mock.handler())
+		defer server.Close()
+
+		results := []sbomResult{
+			{SbomSubject: "broken", SoftwareName: "broken", Error: "lookup timed out", docRef: docRef},
+		}
+		if err := mapSoftwareToComponents(context.Background(), server.Client(), "token", server.URL, results); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if results[0].ComponentID != nil {
+			t.Error("expected error entry to stay unmapped")
+		}
+	})
+
+	t.Run("name exists unoccupied is reused", func(t *testing.T) {
+		mock := newMockPico()
+		existingID := mock.seed("webapp", 0)
+		server := httptest.NewServer(mock.handler())
+		defer server.Close()
+
+		results := []sbomResult{
+			{SbomID: i64Ptr(4), SbomSubject: "webapp", SoftwareID: i64Ptr(40), SoftwareName: "webapp", docRef: docRef},
+		}
+		if err := mapSoftwareToComponents(context.Background(), server.Client(), "token", server.URL, results); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if *results[0].ComponentID != existingID {
+			t.Errorf("expected reuse of existing component %d, got %d", existingID, *results[0].ComponentID)
+		}
+	})
+
+	t.Run("source conflict falls back to hash-suffixed component", func(t *testing.T) {
+		mock := newMockPico()
+		mock.seed("webapp", 99) // occupied by another software
+		server := httptest.NewServer(mock.handler())
+		defer server.Close()
+
+		results := []sbomResult{
+			{SbomID: i64Ptr(4), SbomSubject: "webapp", SoftwareID: i64Ptr(40), SoftwareName: "webapp", docRef: docRef},
+		}
+		if err := mapSoftwareToComponents(context.Background(), server.Client(), "token", server.URL, results); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if results[0].ComponentName == nil || *results[0].ComponentName != "webapp-abcdef1" {
+			t.Errorf("expected fallback component 'webapp-abcdef1', got %v", results[0].ComponentName)
+		}
+	})
+
+	t.Run("hard API failure aborts", func(t *testing.T) {
+		mock := newMockPico()
+		mock.failAll = true
+		server := httptest.NewServer(mock.handler())
+		defer server.Close()
+
+		results := []sbomResult{
+			{SbomID: i64Ptr(1), SbomSubject: "app", SoftwareID: i64Ptr(5), SoftwareName: "app", docRef: docRef},
+		}
+		err := mapSoftwareToComponents(context.Background(), server.Client(), "token", server.URL, results)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "unexpected status 500") {
+			t.Errorf("expected status-500 error, got: %v", err)
+		}
+	})
+}
+
+// componentOf reads the component a software landed in from mock state.
+func (m *mockPico) componentOf(sw int64) int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.swToComp[sw]
+}
+
+func TestFallbackSuffix(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   sbomResult
+		expected string
+	}{
+		{
+			name:     "docRef hash prefix",
+			result:   sbomResult{docRef: "sha256_abcdef1234567890"},
+			expected: "abcdef1",
+		},
+		{
+			name:     "missing docRef falls back to sbom id",
+			result:   sbomResult{SbomID: i64Ptr(777)},
+			expected: "777",
+		},
+		{
+			name:     "malformed docRef falls back to sbom id",
+			result:   sbomResult{docRef: "sha256_ab", SbomID: i64Ptr(777)},
+			expected: "777",
+		},
+		{
+			name:     "nothing available",
+			result:   sbomResult{},
+			expected: "unmapped",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := fallbackSuffix(tt.result); got != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/repo/uploader.go
+++ b/pkg/repo/uploader.go
@@ -118,6 +118,10 @@ type sbomResult struct {
 	ComponentID   *int64  `json:"component_id"`
 	ComponentName *string `json:"component_name"`
 	Error         string  `json:"error,omitempty"`
+
+	// Unexported: not part of the results-file contract. Carries the ssau
+	// docRef so --map-components can derive its fallback name suffix.
+	docRef string
 }
 
 // uploadResults is the envelope written to the --results-file. Wrapped in an
@@ -186,6 +190,7 @@ func Upload(
 	subrepoPath string,
 	commitSha string,
 	resultsFile string,
+	mapComponents bool,
 ) error {
 	// Validate required configuration
 	if filePath == "" {
@@ -194,6 +199,14 @@ func Upload(
 
 	if resultsFile != "" && !wait {
 		return fmt.Errorf("--results-file requires --wait (software IDs are only available after ingestion completes)")
+	}
+
+	if mapComponents && !wait {
+		return fmt.Errorf("--map-components requires --wait (software IDs are only available after ingestion completes)")
+	}
+
+	if mapComponents && isOpenVex {
+		return fmt.Errorf("--map-components applies to SBOM uploads, not OpenVEX documents")
 	}
 
 	if tenantEndpoint == "" {
@@ -474,6 +487,16 @@ func Upload(
 		}
 	}
 
+	// Ensure every ingested software is mapped to a component. Runs before the
+	// results file is written so the file reflects the post-mapping state; on
+	// a mapping failure the file is still written (with whatever mappings
+	// completed) before the error is returned.
+	var mapErr error
+	if mapComponents && len(sbomResults) > 0 {
+		fmt.Fprintf(os.Stderr, "\nMapping ingested software to components...\n")
+		mapErr = mapSoftwareToComponents(context.Background(), client, accessToken, tenantEndpoint, sbomResults)
+	}
+
 	// Write the machine-readable results file. Always written when requested —
 	// even when empty (e.g. no documents ingested successfully) — so pipeline
 	// scripts can rely on the file existing after a successful exit.
@@ -482,6 +505,10 @@ func Upload(
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "Results written to %s\n", resultsFile)
+	}
+
+	if mapErr != nil {
+		return fmt.Errorf("component mapping failed: %w", mapErr)
 	}
 
 	if checkBlockedPackages {
@@ -794,7 +821,7 @@ func lookupSoftwareAndComponentIDs(ctx context.Context, client *http.Client, acc
 		}
 
 		g.Go(func() error {
-			result := sbomResult{SoftwareName: ssau.subject, SbomSubject: ssau.subject}
+			result := sbomResult{SoftwareName: ssau.subject, SbomSubject: ssau.subject, docRef: ssau.docRef}
 
 			ids, err := pollForSoftwareIDs(ctx, client, accessToken, tenantEndpoint, ssau)
 			if err != nil {

--- a/pkg/repo/uploader.go
+++ b/pkg/repo/uploader.go
@@ -86,9 +86,10 @@ type DocumentWrapper struct {
 }
 
 type sbomSubjectAndURI struct {
-	subject string
-	uri     string
-	docRef  string
+	subject  string
+	uri      string
+	docRef   string
+	filePath string
 }
 
 type softwareIDAndSbomID struct {
@@ -110,9 +111,11 @@ type softwareComponentInfo struct {
 // SbomSubject — the SBOM subject is surfaced as "software name" in the
 // frontend, so both names are provided for customer clarity.
 // DO NOT RENAME THESE - CUSTOMERS RELY ON NAMES FOR POST-INGESTION ACTIONS IN CI/CD
+// (adding new fields is fine - the contract is additive)
 type sbomResult struct {
 	SbomID        *int64  `json:"sbom_id"`
 	SbomSubject   string  `json:"sbom_subject"`
+	FilePath      string  `json:"file_path"`
 	SoftwareID    *int64  `json:"software_id"`
 	SoftwareName  string  `json:"software_name"`
 	ComponentID   *int64  `json:"component_id"`
@@ -479,9 +482,7 @@ func Upload(
 					}
 				}
 				if len(successSSaus) > 0 {
-					idResults := lookupSoftwareAndComponentIDs(context.Background(), client, accessToken, tenantEndpoint, successSSaus)
-					printSoftwareAndComponentIDs(idResults)
-					sbomResults = idResults
+					sbomResults = lookupSoftwareAndComponentIDs(context.Background(), client, accessToken, tenantEndpoint, successSSaus)
 				}
 			}
 		}
@@ -495,6 +496,12 @@ func Upload(
 	if mapComponents && len(sbomResults) > 0 {
 		fmt.Fprintf(os.Stderr, "\nMapping ingested software to components...\n")
 		mapErr = mapSoftwareToComponents(context.Background(), client, accessToken, tenantEndpoint, sbomResults)
+	}
+
+	// Print the software table only after mapping, so the COMPONENT columns
+	// show the final assignments rather than the pre-mapping state.
+	if len(sbomResults) > 0 {
+		printSoftwareAndComponentIDs(sbomResults)
 	}
 
 	// Write the machine-readable results file. Always written when requested —
@@ -580,7 +587,12 @@ func uploadSingleFile(client *http.Client, accessToken, tenantEndpoint, filePath
 		return sbomSubjectAndURI{}, err
 	}
 
-	return uploadBlob(client, presignedUrl, filePath, blob, isOpenVex, uploadMeta)
+	ssau, err := uploadBlob(client, presignedUrl, filePath, blob, isOpenVex, uploadMeta)
+	if err != nil {
+		return ssau, err
+	}
+	ssau.filePath = filePath
+	return ssau, nil
 }
 
 // getPresignedUrlForUpload utilizes authorized client to obtain the presigned URL to upload to S3
@@ -741,6 +753,16 @@ func pollForSoftwareIDs(ctx context.Context, client *http.Client, accessToken, t
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Minute)
 	defer cancel()
 
+	// Print the waiting message once, then a "#" per retry on a single line
+	// (rather than a line per 1s poll — a slow ingestion produces hundreds).
+	// The deferred newline terminates the "#" run on every exit path.
+	waits := 0
+	defer func() {
+		if waits > 0 {
+			fmt.Println()
+		}
+	}()
+
 	for {
 		res, err := makePicoRequest(ctx, client, accessToken, tenantEndpoint, fmt.Sprintf("pico/v1/software/id?software_name=%s&sbom_uri=%s",
 			url.QueryEscape(ssau.subject), url.QueryEscape(ssau.uri)))
@@ -763,7 +785,12 @@ func pollForSoftwareIDs(ctx context.Context, client *http.Client, accessToken, t
 			return ids, nil
 		case 404:
 			res.Body.Close() //nolint:errcheck
-			fmt.Printf("  Waiting for SBOM to be ingested (subject: %s)...\n", ssau.subject)
+			if waits == 0 {
+				fmt.Printf("  Waiting for SBOM to be ingested (subject: %s)...\n  ", ssau.subject)
+			} else {
+				fmt.Print("#")
+			}
+			waits++
 			select {
 			case <-ctx.Done():
 				return ids, ctx.Err()
@@ -821,7 +848,7 @@ func lookupSoftwareAndComponentIDs(ctx context.Context, client *http.Client, acc
 		}
 
 		g.Go(func() error {
-			result := sbomResult{SoftwareName: ssau.subject, SbomSubject: ssau.subject, docRef: ssau.docRef}
+			result := sbomResult{SoftwareName: ssau.subject, SbomSubject: ssau.subject, FilePath: ssau.filePath, docRef: ssau.docRef}
 
 			ids, err := pollForSoftwareIDs(ctx, client, accessToken, tenantEndpoint, ssau)
 			if err != nil {
@@ -860,13 +887,17 @@ func lookupSoftwareAndComponentIDs(ctx context.Context, client *http.Client, acc
 
 // printSoftwareAndComponentIDs prints the looked-up IDs as a table on stdout.
 func printSoftwareAndComponentIDs(results []sbomResult) {
-	fmt.Printf("\nSoftware Information:\n")
+	fmt.Printf("\nIngested Software Summary:\n")
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "SBOM SUBJECT/SOFTWARE NAME\tSOFTWARE ID\tCOMPONENT ID\tCOMPONENT NAME")
-	_, _ = fmt.Fprintln(w, "--------------------------\t-----------\t------------\t--------------")
+	_, _ = fmt.Fprintln(w, "SBOM SUBJECT/SOFTWARE NAME\tFILE\tSOFTWARE ID\tCOMPONENT ID\tCOMPONENT NAME")
+	_, _ = fmt.Fprintln(w, "--------------------------\t----\t-----------\t------------\t--------------")
 	for _, r := range results {
+		file := r.FilePath
+		if file == "" {
+			file = "-"
+		}
 		if r.Error != "" {
-			_, _ = fmt.Fprintf(w, "%s\t-\t-\tlookup failed: %s\n", r.SbomSubject, r.Error)
+			_, _ = fmt.Fprintf(w, "%s\t%s\t-\t-\tlookup failed: %s\n", r.SbomSubject, file, r.Error)
 			continue
 		}
 		componentID := "-"
@@ -877,7 +908,7 @@ func printSoftwareAndComponentIDs(results []sbomResult) {
 				componentName = *r.ComponentName
 			}
 		}
-		_, _ = fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", r.SbomSubject, *r.SoftwareID, componentID, componentName)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\n", r.SbomSubject, file, *r.SoftwareID, componentID, componentName)
 	}
 	_ = w.Flush()
 }

--- a/pkg/repo/uploader.go
+++ b/pkg/repo/uploader.go
@@ -474,7 +474,10 @@ func Upload(
 
 			// Report the software ID (and component ID, if the software is already
 			// mapped to a component) for each successfully ingested SBOM.
-			if !isOpenVex {
+			// Only look up IDs when a flag needs them (--results-file or
+			// --map-components): the lookup adds post-ingestion API calls,
+			// so plain uploads skip it entirely.
+			if !isOpenVex && (resultsFile != "" || mapComponents) {
 				var successSSaus []sbomSubjectAndURI
 				for i, r := range results {
 					if r.status == "success" && r.err == nil {
@@ -658,18 +661,31 @@ func uploadBlob(client *http.Client, presignedUrl, filePath string, readFile []b
 	var cdx cdxSBOM
 	if err := json.Unmarshal(readFile, &cdx); err == nil { // inverted error check
 		if cdx.BOMFormat == "CycloneDX" && cdx.Metadata.Component.Name != "" && cdx.SerialNumber != "" {
-			return sbomSubjectAndURI{subject: cdx.Metadata.Component.Name, uri: cdx.SerialNumber, docRef: docRef}, nil
+			return applySubjectNameOverride(sbomSubjectAndURI{subject: cdx.Metadata.Component.Name, uri: cdx.SerialNumber, docRef: docRef}, uploadMeta), nil
 		}
 	}
 
 	var spdx spdxSBOM
 	if err := json.Unmarshal(readFile, &spdx); err == nil { // inverted error check
 		if spdx.SPDXID == "SPDXRef-DOCUMENT" && spdx.Name != "" && spdx.DocumentNamespace != "" {
-			return sbomSubjectAndURI{subject: spdx.Name, uri: spdx.DocumentNamespace + "#DOCUMENT", docRef: docRef}, nil
+			return applySubjectNameOverride(sbomSubjectAndURI{subject: spdx.Name, uri: spdx.DocumentNamespace + "#DOCUMENT", docRef: docRef}, uploadMeta), nil
 		}
 	}
 
 	return sbomSubjectAndURI{docRef: docRef}, nil
+}
+
+// applySubjectNameOverride replaces the file-parsed subject with the
+// sbom_subject_name_override upload metadata value when present. The platform
+// stores the software under the override name, so post-ingestion lookups
+// (software/component IDs, blocked-package checks) must query by it — the
+// file-parsed name would 404 forever. Only applied when a URI was parsed:
+// without one the ID lookup can't match anyway and the entry is skipped.
+func applySubjectNameOverride(ssau sbomSubjectAndURI, uploadMeta map[string]string) sbomSubjectAndURI {
+	if override, ok := uploadMeta["sbom_subject_name_override"]; ok && override != "" && ssau.uri != "" {
+		ssau.subject = override
+	}
+	return ssau
 }
 
 // checkSBOMsForBlockedPackages checks if uploaded SBOMs contain any blocked packages

--- a/pkg/repo/uploader.go
+++ b/pkg/repo/uploader.go
@@ -682,6 +682,7 @@ func checkSBOMsForBlockedPackages(ctx context.Context, client *http.Client, acce
 
 	blocked := make([]bool, len(ssaus))
 	blockedPurls := make([][]string, len(ssaus))
+	progress := newWaitPrinter(os.Stdout)
 
 	for i, ssau := range ssaus {
 		if ssau.subject == "" && ssau.uri == "" {
@@ -690,7 +691,7 @@ func checkSBOMsForBlockedPackages(ctx context.Context, client *http.Client, acce
 
 		g.Go(func() error {
 			// Poll for software/SBOM IDs until available
-			ids, err := pollForSoftwareIDs(ctx, client, accessToken, tenantEndpoint, ssau)
+			ids, err := pollForSoftwareIDs(ctx, client, accessToken, tenantEndpoint, ssau, progress)
 			if err != nil {
 				return err
 			}
@@ -726,7 +727,9 @@ func checkSBOMsForBlockedPackages(ctx context.Context, client *http.Client, acce
 		})
 	}
 
-	if err := g.Wait(); err != nil {
+	err := g.Wait()
+	progress.close()
+	if err != nil {
 		return false, err
 	}
 
@@ -747,21 +750,11 @@ func checkSBOMsForBlockedPackages(ctx context.Context, client *http.Client, acce
 // SBOM IDs for the given SBOM subject/URI are available (the SBOM has been ingested),
 // or the context is cancelled. A hard 15-minute cap applies even when the caller's
 // context has no deadline.
-func pollForSoftwareIDs(ctx context.Context, client *http.Client, accessToken, tenantEndpoint string, ssau sbomSubjectAndURI) (softwareIDAndSbomID, error) {
+func pollForSoftwareIDs(ctx context.Context, client *http.Client, accessToken, tenantEndpoint string, ssau sbomSubjectAndURI, progress *waitPrinter) (softwareIDAndSbomID, error) {
 	var ids softwareIDAndSbomID
 
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Minute)
 	defer cancel()
-
-	// Print the waiting message once, then a "#" per retry on a single line
-	// (rather than a line per 1s poll — a slow ingestion produces hundreds).
-	// The deferred newline terminates the "#" run on every exit path.
-	waits := 0
-	defer func() {
-		if waits > 0 {
-			fmt.Println()
-		}
-	}()
 
 	for {
 		res, err := makePicoRequest(ctx, client, accessToken, tenantEndpoint, fmt.Sprintf("pico/v1/software/id?software_name=%s&sbom_uri=%s",
@@ -785,12 +778,7 @@ func pollForSoftwareIDs(ctx context.Context, client *http.Client, accessToken, t
 			return ids, nil
 		case 404:
 			res.Body.Close() //nolint:errcheck
-			if waits == 0 {
-				fmt.Printf("  Waiting for SBOM to be ingested (subject: %s)...\n  ", ssau.subject)
-			} else {
-				fmt.Print("#")
-			}
-			waits++
+			progress.tick()
 			select {
 			case <-ctx.Done():
 				return ids, ctx.Err()
@@ -841,6 +829,7 @@ func lookupSoftwareAndComponentIDs(ctx context.Context, client *http.Client, acc
 	g.SetLimit(5)
 
 	results := make([]sbomResult, len(ssaus))
+	progress := newWaitPrinter(os.Stdout)
 
 	for i, ssau := range ssaus {
 		if ssau.subject == "" && ssau.uri == "" {
@@ -850,7 +839,7 @@ func lookupSoftwareAndComponentIDs(ctx context.Context, client *http.Client, acc
 		g.Go(func() error {
 			result := sbomResult{SoftwareName: ssau.subject, SbomSubject: ssau.subject, FilePath: ssau.filePath, docRef: ssau.docRef}
 
-			ids, err := pollForSoftwareIDs(ctx, client, accessToken, tenantEndpoint, ssau)
+			ids, err := pollForSoftwareIDs(ctx, client, accessToken, tenantEndpoint, ssau, progress)
 			if err != nil {
 				result.Error = err.Error()
 				results[i] = result
@@ -873,6 +862,7 @@ func lookupSoftwareAndComponentIDs(ctx context.Context, client *http.Client, acc
 	}
 
 	_ = g.Wait() // Goroutines never return errors; individual errors are in results
+	progress.close()
 
 	// Drop entries skipped for having no subject/URI parsed from the document
 	filtered := make([]sbomResult, 0, len(results))

--- a/pkg/repo/uploader_test.go
+++ b/pkg/repo/uploader_test.go
@@ -1333,10 +1333,10 @@ func TestUpload_ValidationErrors(t *testing.T) {
 				"",
 				false,
 				false,
-				"", // forge
-				"", // org
-				"", // repo
-				"", // subrepoPath
+				"",    // forge
+				"",    // org
+				"",    // repo
+				"",    // subrepoPath
 				"",    // commit sha
 				"",    // resultsFile
 				false, // mapComponents

--- a/pkg/repo/uploader_test.go
+++ b/pkg/repo/uploader_test.go
@@ -960,6 +960,7 @@ func TestWriteResultsFile(t *testing.T) {
 				{
 					SoftwareName:  "my-app",
 					SbomSubject:   "my-app",
+					FilePath:      "sboms/my-app.cdx.json",
 					SoftwareID:    int64Ptr(42),
 					SbomID:        int64Ptr(7),
 					ComponentID:   int64Ptr(9),
@@ -971,6 +972,7 @@ func TestWriteResultsFile(t *testing.T) {
     {
       "sbom_id": 7,
       "sbom_subject": "my-app",
+      "file_path": "sboms/my-app.cdx.json",
       "software_id": 42,
       "software_name": "my-app",
       "component_id": 9,
@@ -995,6 +997,7 @@ func TestWriteResultsFile(t *testing.T) {
     {
       "sbom_id": 7,
       "sbom_subject": "my-app",
+      "file_path": "",
       "software_id": 42,
       "software_name": "my-app",
       "component_id": null,

--- a/pkg/repo/uploader_test.go
+++ b/pkg/repo/uploader_test.go
@@ -6,6 +6,7 @@ package repo
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -773,7 +774,7 @@ func TestPollForSoftwareIDs(t *testing.T) {
 			defer server.Close()
 
 			ids, err := pollForSoftwareIDs(context.Background(), server.Client(), "test-token", server.URL,
-				sbomSubjectAndURI{subject: "my-app", uri: "urn:uuid:12345"})
+				sbomSubjectAndURI{subject: "my-app", uri: "urn:uuid:12345"}, newWaitPrinter(io.Discard))
 
 			if tt.expectError {
 				if err == nil {
@@ -809,13 +810,20 @@ func TestPollForSoftwareIDsRetriesOn404(t *testing.T) {
 	}))
 	defer server.Close()
 
+	progressOut := &strings.Builder{}
+	progress := newWaitPrinter(progressOut)
 	ids, err := pollForSoftwareIDs(context.Background(), server.Client(), "test-token", server.URL,
-		sbomSubjectAndURI{subject: "my-app", uri: "urn:uuid:12345"})
+		sbomSubjectAndURI{subject: "my-app", uri: "urn:uuid:12345"}, progress)
+	progress.close()
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	if attempts != 2 {
 		t.Errorf("Expected 2 attempts, got %d", attempts)
+	}
+	expectedProgress := "  Waiting for software info for ingested SBOMs...\n  #\n"
+	if progressOut.String() != expectedProgress {
+		t.Errorf("Expected progress output %q, got %q", expectedProgress, progressOut.String())
 	}
 	if ids.SoftwareID != 42 {
 		t.Errorf("Expected software ID 42, got %d", ids.SoftwareID)

--- a/pkg/repo/uploader_test.go
+++ b/pkg/repo/uploader_test.go
@@ -112,6 +112,24 @@ func TestUploadBlob(t *testing.T) {
 			expectedURI:     "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
 		},
 		{
+			name: "subject name override replaces file-parsed subject",
+			fileContent: `{
+				"bomFormat": "CycloneDX",
+				"serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+				"metadata": {
+					"component": {
+						"name": "my-app"
+					}
+				}
+			}`,
+			isOpenVex:       false,
+			uploadMeta:      map[string]string{"sbom_subject_name_override": "renamed-app"},
+			serverStatus:    http.StatusOK,
+			expectError:     false,
+			expectedSubject: "renamed-app",
+			expectedURI:     "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+		},
+		{
 			name: "successful SPDX upload",
 			fileContent: `{
 				"SPDXID": "SPDXRef-DOCUMENT",

--- a/pkg/repo/uploader_test.go
+++ b/pkg/repo/uploader_test.go
@@ -1046,12 +1046,55 @@ func TestUploadResultsFileRequiresWait(t *testing.T) {
 		false, // wait
 		"", "", "", "", "",
 		"results.json",
+		false, // mapComponents
 	)
 	if err == nil {
 		t.Fatal("Expected error, got nil")
 	}
 	if !strings.Contains(err.Error(), "requires --wait") {
 		t.Errorf("Expected error containing 'requires --wait', got '%s'", err.Error())
+	}
+}
+
+func TestUploadMapComponentsRequiresWait(t *testing.T) {
+	err := Upload(
+		"/test/file.json",
+		"https://test.com",
+		"", "", "",
+		false, // isOpenVex
+		"", "", "", "", "",
+		false, // checkBlockedPackages
+		false, // wait
+		"", "", "", "", "",
+		"",   // resultsFile
+		true, // mapComponents
+	)
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--map-components requires --wait") {
+		t.Errorf("Expected error containing '--map-components requires --wait', got '%s'", err.Error())
+	}
+}
+
+func TestUploadMapComponentsRejectsOpenVex(t *testing.T) {
+	err := Upload(
+		"/test/file.json",
+		"https://test.com",
+		"", "", "",
+		true, // isOpenVex
+		"", "", "", "", "",
+		false, // checkBlockedPackages
+		true,  // wait
+		"", "", "", "", "",
+		"",   // resultsFile
+		true, // mapComponents
+	)
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not OpenVEX") {
+		t.Errorf("Expected error containing 'not OpenVEX', got '%s'", err.Error())
 	}
 }
 
@@ -1283,8 +1326,9 @@ func TestUpload_ValidationErrors(t *testing.T) {
 				"", // org
 				"", // repo
 				"", // subrepoPath
-				"", // commit sha
-				"", // resultsFile
+				"",    // commit sha
+				"",    // resultsFile
+				false, // mapComponents
 			)
 
 			if !tt.expectError {

--- a/pkg/repo/wait_printer.go
+++ b/pkg/repo/wait_printer.go
@@ -1,0 +1,49 @@
+// Copyright (c) Kusari <https://www.kusari.dev/>
+// SPDX-License-Identifier: MIT
+
+package repo
+
+import (
+	"fmt"
+	"io"
+	"sync"
+)
+
+// waitPrinter prints a single shared progress line for the concurrent
+// software-info pollers: a header on the first wait, then one '#' per poll
+// retry across all pollers. close() terminates the line once polling is
+// done. Per-file outcomes (including lookup failures) are reported in the
+// results table afterwards, so the progress line doesn't attribute waits to
+// individual files.
+type waitPrinter struct {
+	mu      sync.Mutex
+	out     io.Writer
+	started bool
+}
+
+func newWaitPrinter(out io.Writer) *waitPrinter {
+	return &waitPrinter{out: out}
+}
+
+// tick records one poll retry, printing the header on the first wait.
+func (p *waitPrinter) tick() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.started {
+		p.started = true
+		_, _ = fmt.Fprint(p.out, "  Waiting for software info for ingested SBOMs...\n  ")
+	}
+	_, _ = fmt.Fprint(p.out, "#")
+}
+
+// close terminates the progress line. No-op if nothing ever waited.
+func (p *waitPrinter) close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.started {
+		p.started = false
+		_, _ = fmt.Fprintln(p.out)
+	}
+}

--- a/pkg/repo/wait_printer_test.go
+++ b/pkg/repo/wait_printer_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) Kusari <https://www.kusari.dev/>
+// SPDX-License-Identifier: MIT
+
+package repo
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWaitPrinter(t *testing.T) {
+	t.Run("header once then a hash per tick", func(t *testing.T) {
+		out := &strings.Builder{}
+		p := newWaitPrinter(out)
+		p.tick()
+		p.tick()
+		p.tick()
+		p.close()
+		expected := "  Waiting for software info for ingested SBOMs...\n  ###\n"
+		if out.String() != expected {
+			t.Errorf("expected %q, got %q", expected, out.String())
+		}
+	})
+
+	t.Run("close without waiting prints nothing", func(t *testing.T) {
+		out := &strings.Builder{}
+		p := newWaitPrinter(out)
+		p.close()
+		if out.String() != "" {
+			t.Errorf("expected no output, got %q", out.String())
+		}
+	})
+
+	t.Run("close is idempotent", func(t *testing.T) {
+		out := &strings.Builder{}
+		p := newWaitPrinter(out)
+		p.tick()
+		p.close()
+		p.close()
+		expected := "  Waiting for software info for ingested SBOMs...\n  #\n"
+		if out.String() != expected {
+			t.Errorf("expected %q, got %q", expected, out.String())
+		}
+	})
+}


### PR DESCRIPTION
Let the user pass in a flag for us to map orphaned software to components for them, and handle edge cases

Logic is:

1. if no "component id" on ingested software
- create new component with that ingested software's name as the component name
    - if component with that name already exists for some reason, then add this software to that component
        - if that existing component already has a source software and this is a source software so it errors, make a new component instead with the software name + part of the commit sha as a random string to make a unique name
- assign software to that new component

2. if there is a component id on existing software
- don't do anything extra after ingestion