### PR TITLE
Add `kusari connectivity check` preflight command

### DIFF
--- a/kusari/cmd/auth_login.go
+++ b/kusari/cmd/auth_login.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/kusaridev/kusari-cli/v2/pkg/constants"
 	l "github.com/kusaridev/kusari-cli/v2/pkg/login"
 	"github.com/kusaridev/kusari-cli/v2/pkg/port"
 	"github.com/spf13/cobra"
@@ -20,7 +21,7 @@ var (
 )
 
 func init() {
-	logincmd.Flags().StringVarP(&authEndpoint, "auth-endpoint", "p", "https://auth.us.kusari.cloud/", "authentication endpoint URL")
+	logincmd.Flags().StringVarP(&authEndpoint, "auth-endpoint", "p", constants.DefaultAuthURL, "authentication endpoint URL")
 	logincmd.Flags().StringVarP(&clientId, "client-id", "c", "4lnk6jccl3hc4lkcudai5lt36u", "OAuth2 client ID")
 	logincmd.Flags().StringVarP(&clientSecret, "client-secret", "s", "", "OAuth client secret ")
 	logincmd.Flags().BoolVar(&useSso, "use-sso", false, "Use SSO (SAML) authentication")

--- a/kusari/cmd/connectivity.go
+++ b/kusari/cmd/connectivity.go
@@ -10,7 +10,7 @@ import (
 func Connectivity() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "connectivity",
-		Aliases: []string{"conn", "net", "preflight"},
+		Aliases: []string{"conn"},
 		Short:   "Diagnose network connectivity to Kusari endpoints",
 		Long:    "Diagnose DNS, TCP, TLS and HTTP proxy connectivity between this machine and the Kusari services the CLI uses",
 	}

--- a/kusari/cmd/connectivity.go
+++ b/kusari/cmd/connectivity.go
@@ -1,0 +1,21 @@
+// Copyright (c) Kusari <https://www.kusari.dev/>
+// SPDX-License-Identifier: MIT
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func Connectivity() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "connectivity",
+		Aliases: []string{"conn", "net", "preflight"},
+		Short:   "Diagnose network connectivity to Kusari endpoints",
+		Long:    "Diagnose DNS, TCP, TLS and HTTP proxy connectivity between this machine and the Kusari services the CLI uses",
+	}
+
+	cmd.AddCommand(connectivityCheck())
+
+	return cmd
+}

--- a/kusari/cmd/connectivity_check.go
+++ b/kusari/cmd/connectivity_check.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kusaridev/kusari-cli/v2/pkg/auth"
 	"github.com/kusaridev/kusari-cli/v2/pkg/connectivity"
 	"github.com/kusaridev/kusari-cli/v2/pkg/constants"
 	"github.com/spf13/cobra"
@@ -58,11 +57,10 @@ environment variables.`,
 				AuthURL:     authEndpointFromConfig(),
 				PlatformURL: platformUrl,
 				ConsoleURL:  consoleUrl,
-				Tenant:      tenantFromConfig(),
 			}
 
 			targets := connectivity.DefaultTargets(endpoints)
-			allowlist := connectivity.AllowlistHosts(endpoints, targets)
+			allowlist := connectivity.AllowlistHosts(targets)
 			proxyEnv := connectivity.ProxyEnvConfig(os.Getenv)
 
 			printCheckHeader(proxyEnv)
@@ -112,41 +110,6 @@ func authEndpointFromConfig() string {
 		return v
 	}
 	return constants.DefaultAuthURL
-}
-
-// tenantFromConfig resolves the tenant for the SBOM upload bucket hostname,
-// mirroring platform.go's precedence without re-binding those viper keys.
-// Returns "" when no tenant is known, in which case the tenant-specific bucket
-// is not probed rather than guessed at.
-func tenantFromConfig() string {
-	if v := strings.TrimSpace(viper.GetString("tenant-endpoint")); v != "" {
-		return tenantFromEndpoint(v)
-	}
-	if v := strings.TrimSpace(viper.GetString("tenant")); v != "" {
-		return v
-	}
-	workspace, err := auth.LoadWorkspace(platformUrl, "")
-	if err != nil {
-		if verbose {
-			fmt.Fprintf(os.Stderr, "Note: could not load workspace configuration: %v\n", err)
-		}
-		return ""
-	}
-	return workspace.Tenant
-}
-
-// tenantFromEndpoint takes the first hostname label, as pkg/repo/uploader.go
-// does when recovering a tenant name from an endpoint.
-func tenantFromEndpoint(endpoint string) string {
-	host := endpoint
-	if u, err := url.Parse(endpoint); err == nil && u.Host != "" {
-		host = u.Hostname()
-	}
-	label, _, found := strings.Cut(host, ".")
-	if !found {
-		return ""
-	}
-	return label
 }
 
 func printCheckHeader(proxyEnv connectivity.ProxyConfig) {
@@ -271,9 +234,6 @@ func printAllowlist(hosts []connectivity.AllowlistHost, proxyEnv connectivity.Pr
 	for _, h := range hosts {
 		fmt.Printf("  • %s\n", h.Host)
 		fmt.Printf("    Purpose: %s\n", h.Purpose)
-		if strings.Contains(h.Host, "<tenant>") {
-			fmt.Printf("    Replace <tenant> with your tenant name (`kusari auth login` sets it).\n")
-		}
 		fmt.Println()
 	}
 	if proxyEnv.HTTP != "" || proxyEnv.HTTPS != "" {

--- a/kusari/cmd/connectivity_check.go
+++ b/kusari/cmd/connectivity_check.go
@@ -1,0 +1,357 @@
+// Copyright (c) Kusari <https://www.kusari.dev/>
+// SPDX-License-Identifier: MIT
+
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/kusaridev/kusari-cli/v2/pkg/auth"
+	"github.com/kusaridev/kusari-cli/v2/pkg/connectivity"
+	"github.com/kusaridev/kusari-cli/v2/pkg/constants"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	ruleWidth  = 70
+	nameColumn = 13
+)
+
+func connectivityCheck() *cobra.Command {
+	var (
+		timeout    time.Duration
+		reportPath string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "check",
+		Short: "Check network connectivity to Kusari endpoints",
+		Long: `Verify that this machine can reach the endpoints the Kusari CLI needs.
+
+Each endpoint is probed with an unauthenticated GET. An endpoint counts as
+reachable when the TLS handshake completes and any HTTP status is returned,
+including 401, 403, 404, 307 and 5xx: this checks the network path, not
+authentication, authorization or service health.
+
+Proxy settings are taken from the standard HTTP_PROXY, HTTPS_PROXY and NO_PROXY
+environment variables, exactly like every other Kusari CLI command. There is
+deliberately no --proxy flag, so a passing check reflects what the rest of the
+CLI will actually do.
+
+Endpoints can be overridden with --platform-url and --console-url, or with the
+KUSARI_PLATFORM_URL, KUSARI_CONSOLE_URL, KUSARI_AUTH_ENDPOINT and KUSARI_TENANT
+environment variables.`,
+		Example: `  kusari connectivity check
+  kusari conn check --timeout 30s --verbose
+  kusari preflight check --report kusari-preflight.json
+  HTTPS_PROXY=http://proxy.corp:8080 kusari net check`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+
+			endpoints := connectivity.Endpoints{
+				AuthURL:     authEndpointFromConfig(),
+				PlatformURL: platformUrl,
+				ConsoleURL:  consoleUrl,
+				Tenant:      tenantFromConfig(),
+			}
+
+			targets := connectivity.DefaultTargets(endpoints)
+			allowlist := connectivity.AllowlistHosts(targets)
+			proxyEnv := connectivity.ProxyEnvConfig(os.Getenv)
+
+			printCheckHeader(proxyEnv)
+
+			results := connectivity.Check(cmd.Context(), targets, connectivity.Options{
+				Timeout: timeout,
+			})
+
+			printResults(results)
+			if endpoints.Tenant == "" {
+				fmt.Println("Skipped: the tenant-specific SBOM upload bucket, because no tenant is")
+				fmt.Println("  configured. Run `kusari auth login`, or set KUSARI_TENANT, to include it.")
+				fmt.Println()
+			}
+			printFailures(results)
+			printAllowlist(allowlist, proxyEnv)
+
+			if reportPath != "" {
+				rep := connectivity.BuildReport(results, allowlist, getVersion(), proxyEnv, time.Now())
+				if err := connectivity.WriteReport(reportPath, rep); err != nil {
+					return err
+				}
+				fmt.Printf("Report written to %s\n", reportPath)
+			}
+
+			var failed []string
+			for _, r := range results {
+				if !r.OK() {
+					failed = append(failed, r.Target.Name)
+				}
+			}
+			if len(failed) > 0 {
+				return fmt.Errorf("connectivity check failed: %d of %d endpoints unreachable (%s)",
+					len(failed), len(results), strings.Join(failed, ", "))
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().DurationVar(&timeout, "timeout", connectivity.DefaultTimeout, "Per-endpoint timeout")
+	cmd.Flags().StringVar(&reportPath, "report", "", "Write a JSON report to this path (for support tickets)")
+
+	return cmd
+}
+
+// authEndpointFromConfig reads the auth endpoint. Do NOT bind a flag to
+// "auth-endpoint" here: viper keeps one pflag per key, so a second binding would
+// overwrite auth_login.go's and silently discard `auth login --auth-endpoint`.
+// Reading the key still picks up KUSARI_AUTH_ENDPOINT and .env.
+func authEndpointFromConfig() string {
+	if v := strings.TrimSpace(viper.GetString("auth-endpoint")); v != "" {
+		return v
+	}
+	return constants.DefaultAuthURL
+}
+
+// tenantFromConfig resolves the tenant for the SBOM upload bucket hostname,
+// mirroring platform.go's precedence without re-binding those viper keys.
+// Returns "" when no tenant is known, in which case the tenant-specific bucket
+// is not probed rather than guessed at.
+func tenantFromConfig() string {
+	if v := strings.TrimSpace(viper.GetString("tenant-endpoint")); v != "" {
+		return tenantFromEndpoint(v)
+	}
+	if v := strings.TrimSpace(viper.GetString("tenant")); v != "" {
+		return v
+	}
+	workspace, err := auth.LoadWorkspace(platformUrl, "")
+	if err != nil {
+		if verbose {
+			fmt.Fprintf(os.Stderr, "Note: could not load workspace configuration: %v\n", err)
+		}
+		return ""
+	}
+	return workspace.Tenant
+}
+
+// tenantFromEndpoint takes the first hostname label, as pkg/repo/uploader.go
+// does when recovering a tenant name from an endpoint.
+func tenantFromEndpoint(endpoint string) string {
+	host := endpoint
+	if u, err := url.Parse(endpoint); err == nil && u.Host != "" {
+		host = u.Hostname()
+	}
+	label, _, found := strings.Cut(host, ".")
+	if !found {
+		return ""
+	}
+	return label
+}
+
+func printCheckHeader(proxyEnv connectivity.ProxyConfig) {
+	fmt.Println(strings.Repeat("=", ruleWidth))
+	fmt.Println("Kusari Connectivity Check")
+	fmt.Println(strings.Repeat("=", ruleWidth))
+	fmt.Println()
+	fmt.Println("Proxy configuration (from environment):")
+	fmt.Printf("  HTTPS_PROXY  %s\n", orNotSet(proxyEnv.HTTPS))
+	fmt.Printf("  HTTP_PROXY   %s\n", orNotSet(proxyEnv.HTTP))
+	fmt.Printf("  NO_PROXY     %s\n", orNotSet(proxyEnv.NoProxy))
+	fmt.Println()
+}
+
+func printResults(results []connectivity.Result) {
+	fmt.Println(strings.Repeat("-", ruleWidth))
+
+	reachable := 0
+	for _, r := range results {
+		glyph := "✗"
+		if r.OK() {
+			glyph = "✓"
+			reachable++
+		}
+		fmt.Printf("  %s %-*s %s\n", glyph, nameColumn, r.Target.Name, r.Target.URL)
+
+		detail := fmt.Sprintf("FAILED: %s", r.Diag.Summary)
+		if r.OK() {
+			detail = fmt.Sprintf("HTTP %s", r.Status)
+		}
+		route := "direct"
+		if r.Proxy != nil {
+			route = "via " + connectivity.ProxyLabel(r.Proxy)
+		}
+		fmt.Printf("      %*s%s  |  %s  |  %s\n", nameColumn, "", detail,
+			formatDuration(r.Duration), route)
+
+		if r.ServiceError() {
+			fmt.Printf("      %*sNOTE: 5xx indicates a Kusari service issue, not a network\n", nameColumn, "")
+			fmt.Printf("      %*s      problem on your side. Contact %s.\n", nameColumn, "", connectivity.SupportEmail)
+		}
+
+		if verbose {
+			printVerboseDetail(r)
+		}
+	}
+
+	fmt.Println(strings.Repeat("-", ruleWidth))
+	fmt.Printf("Total: %d targets | Reachable: %d | Unreachable: %d\n",
+		len(results), reachable, len(results)-reachable)
+	fmt.Println()
+
+	if reachable == len(results) {
+		fmt.Println("All endpoints reachable.")
+		fmt.Println("  401/403/404/307 and 5xx count as reachable: this check is unauthenticated")
+		fmt.Println("  and only verifies DNS, TCP, TLS and proxy connectivity.")
+		fmt.Println()
+	}
+}
+
+func printVerboseDetail(r connectivity.Result) {
+	pad := fmt.Sprintf("      %*s", nameColumn, "")
+	if r.TLS != nil {
+		fmt.Printf("%s%s (%s)\n", pad, r.TLS.Version, r.TLS.CipherSuite)
+		if r.TLS.PeerSubjectCN != "" || r.TLS.PeerIssuerCN != "" {
+			fmt.Printf("%scert %q issued by %q\n", pad, r.TLS.PeerSubjectCN, r.TLS.PeerIssuerCN)
+		}
+	}
+	if r.Location != "" {
+		fmt.Printf("%sLocation: %s (not followed)\n", pad, locationForDisplay(r.Location))
+	}
+	if r.Diag.Raw != "" {
+		fmt.Fprintf(os.Stderr, "%s%s\n", pad, r.Diag.Raw)
+	}
+}
+
+func printFailures(results []connectivity.Result) {
+	var failures []connectivity.Result
+	for _, r := range results {
+		if !r.OK() {
+			failures = append(failures, r)
+		}
+	}
+	if len(failures) == 0 {
+		return
+	}
+
+	fmt.Println("Failures")
+	fmt.Println(strings.Repeat("-", ruleWidth))
+	for _, r := range failures {
+		fmt.Printf("✗ %s - %s\n", r.Target.Name, r.Target.Purpose)
+		fmt.Printf("  Endpoint: %s\n", r.Target.URL)
+		if s := connectivity.ProxySummary(r.Proxy); s != "" {
+			fmt.Printf("  Proxy:    %s\n", s)
+		} else {
+			fmt.Printf("  Proxy:    (direct connection)\n")
+		}
+		fmt.Printf("  Category: %s\n", r.Diag.Category)
+		if r.Diag.Cause != "" {
+			printWrapped("  Cause:    ", r.Diag.Cause)
+		}
+		if len(r.Diag.Remediation) > 0 {
+			fmt.Println("  Fix:")
+			for i, step := range r.Diag.Remediation {
+				printWrapped(fmt.Sprintf("    %d. ", i+1), step)
+			}
+		}
+		fmt.Println()
+	}
+	fmt.Println(strings.Repeat("-", ruleWidth))
+	if !verbose {
+		fmt.Println("Re-run with --verbose for the raw transport errors.")
+	}
+	fmt.Println()
+}
+
+func printAllowlist(hosts []connectivity.AllowlistHost, proxyEnv connectivity.ProxyConfig) {
+	fmt.Println("Network Requirements")
+	fmt.Println(strings.Repeat("-", ruleWidth))
+	fmt.Println("Allow outbound HTTPS (TCP 443) to the following hostnames:")
+	fmt.Println()
+	for _, h := range hosts {
+		fmt.Printf("  • %s\n", h.Host)
+		fmt.Printf("    Purpose: %s\n", h.Purpose)
+		fmt.Println()
+	}
+	if proxyEnv.HTTP != "" || proxyEnv.HTTPS != "" {
+		fmt.Println("  Proxy: configured via HTTP_PROXY/HTTPS_PROXY")
+	} else {
+		fmt.Println("  Proxy: none configured (direct connection)")
+	}
+	fmt.Println()
+	fmt.Println("Important:")
+	fmt.Println("  • Use hostnames, not IP addresses, in firewall and proxy rules.")
+	fmt.Println("    The underlying addresses change frequently.")
+	fmt.Println()
+	fmt.Printf("For assistance, contact %s.\n", connectivity.SupportEmail)
+	fmt.Println(strings.Repeat("=", ruleWidth))
+}
+
+// printWrapped prints text after prefix, aligning continuation lines under it.
+func printWrapped(prefix, text string) {
+	indent := strings.Repeat(" ", len(prefix))
+	limit := ruleWidth - len(prefix)
+	if limit < 20 {
+		limit = 20
+	}
+
+	line := ""
+	first := true
+	flush := func() {
+		if first {
+			fmt.Printf("%s%s\n", prefix, line)
+			first = false
+		} else {
+			fmt.Printf("%s%s\n", indent, line)
+		}
+		line = ""
+	}
+
+	for _, word := range strings.Fields(text) {
+		switch {
+		case line == "":
+			line = word
+		case len(line)+1+len(word) <= limit:
+			line += " " + word
+		default:
+			flush()
+			line = word
+		}
+	}
+	if line != "" {
+		flush()
+	}
+}
+
+// locationForDisplay strips the query from a redirect target: OAuth redirects
+// carry state tokens, and this output gets pasted into support tickets.
+func locationForDisplay(location string) string {
+	u, err := url.Parse(location)
+	if err != nil || u.Host == "" {
+		return location
+	}
+	shown := u.Scheme + "://" + u.Host + u.Path
+	if u.RawQuery != "" {
+		shown += "?…"
+	}
+	return shown
+}
+
+func formatDuration(d time.Duration) string {
+	if d < time.Second {
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	}
+	return fmt.Sprintf("%.3fs", d.Seconds())
+}
+
+func orNotSet(v string) string {
+	if v == "" {
+		return "(not set)"
+	}
+	return v
+}

--- a/kusari/cmd/connectivity_check.go
+++ b/kusari/cmd/connectivity_check.go
@@ -62,7 +62,7 @@ environment variables.`,
 			}
 
 			targets := connectivity.DefaultTargets(endpoints)
-			allowlist := connectivity.AllowlistHosts(targets)
+			allowlist := connectivity.AllowlistHosts(endpoints, targets)
 			proxyEnv := connectivity.ProxyEnvConfig(os.Getenv)
 
 			printCheckHeader(proxyEnv)
@@ -72,11 +72,6 @@ environment variables.`,
 			})
 
 			printResults(results)
-			if endpoints.Tenant == "" {
-				fmt.Println("Skipped: the tenant-specific SBOM upload bucket, because no tenant is")
-				fmt.Println("  configured. Run `kusari auth login`, or set KUSARI_TENANT, to include it.")
-				fmt.Println()
-			}
 			printFailures(results)
 			printAllowlist(allowlist, proxyEnv)
 
@@ -276,6 +271,9 @@ func printAllowlist(hosts []connectivity.AllowlistHost, proxyEnv connectivity.Pr
 	for _, h := range hosts {
 		fmt.Printf("  • %s\n", h.Host)
 		fmt.Printf("    Purpose: %s\n", h.Purpose)
+		if strings.Contains(h.Host, "<tenant>") {
+			fmt.Printf("    Replace <tenant> with your tenant name (`kusari auth login` sets it).\n")
+		}
 		fmt.Println()
 	}
 	if proxyEnv.HTTP != "" || proxyEnv.HTTPS != "" {

--- a/kusari/cmd/connectivity_check.go
+++ b/kusari/cmd/connectivity_check.go
@@ -48,8 +48,8 @@ KUSARI_PLATFORM_URL, KUSARI_CONSOLE_URL, KUSARI_AUTH_ENDPOINT and KUSARI_TENANT
 environment variables.`,
 		Example: `  kusari connectivity check
   kusari conn check --timeout 30s --verbose
-  kusari preflight check --report kusari-preflight.json
-  HTTPS_PROXY=http://proxy.corp:8080 kusari net check`,
+  kusari connectivity check --report kusari-preflight.json
+  HTTPS_PROXY=http://proxy.corp:8080 kusari conn check`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true

--- a/kusari/cmd/connectivity_check_test.go
+++ b/kusari/cmd/connectivity_check_test.go
@@ -171,7 +171,7 @@ func TestConnectivityCommandShape(t *testing.T) {
 	cmd := Connectivity()
 
 	assert.Equal(t, "connectivity", cmd.Name())
-	assert.ElementsMatch(t, []string{"conn", "net", "preflight"}, cmd.Aliases)
+	assert.ElementsMatch(t, []string{"conn"}, cmd.Aliases)
 
 	sub := cmd.Commands()
 	require.Len(t, sub, 1)

--- a/kusari/cmd/connectivity_check_test.go
+++ b/kusari/cmd/connectivity_check_test.go
@@ -1,0 +1,231 @@
+// Copyright (c) Kusari <https://www.kusari.dev/>
+// SPDX-License-Identifier: MIT
+
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kusaridev/kusari-cli/v2/pkg/constants"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetViper(t *testing.T) {
+	t.Helper()
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+}
+
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns what it
+// wrote. The printing helpers write to stdout directly, matching the rest of
+// this package.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+	require.NoError(t, w.Close())
+	out := <-done
+	require.NoError(t, r.Close())
+	return out
+}
+
+func TestAuthEndpointFromConfig(t *testing.T) {
+	t.Run("falls back to the shared constant", func(t *testing.T) {
+		resetViper(t)
+		assert.Equal(t, constants.DefaultAuthURL, authEndpointFromConfig())
+	})
+
+	t.Run("honors the auth-endpoint key", func(t *testing.T) {
+		resetViper(t)
+		viper.Set("auth-endpoint", "https://auth.eu.kusari.cloud/")
+		assert.Equal(t, "https://auth.eu.kusari.cloud/", authEndpointFromConfig())
+	})
+
+	t.Run("treats whitespace as unset", func(t *testing.T) {
+		resetViper(t)
+		viper.Set("auth-endpoint", "   ")
+		assert.Equal(t, constants.DefaultAuthURL, authEndpointFromConfig())
+	})
+}
+
+// Regression guard for a silent, high-impact failure mode.
+//
+// viper keeps ONE bound pflag per key. `kusari auth login` binds
+// "auth-endpoint" (auth_login.go); the connectivity command must only READ that
+// key, never bind a second flag to it. If someone adds a competing binding,
+// init() ordering (filename order within package cmd) decides the winner, and
+// viper.find would fall through to the wrong flag's default -- silently
+// discarding `auth login --auth-endpoint=...` and logging the user into the
+// wrong region.
+func TestConnectivityDoesNotStealAuthEndpointBinding(t *testing.T) {
+	resetViper(t)
+
+	// Re-bind exactly as auth_login.go's init() does, then simulate the user
+	// passing the flag.
+	fresh := &cobra.Command{Use: "login"}
+	fresh.Flags().String("auth-endpoint", constants.DefaultAuthURL, "authentication endpoint URL")
+	require.NoError(t, viper.BindPFlag("auth-endpoint", fresh.Flags().Lookup("auth-endpoint")))
+	require.NoError(t, fresh.Flags().Set("auth-endpoint", "https://auth.eu.kusari.cloud/"))
+
+	// The user's override must survive, both through viper directly and through
+	// the helper the connectivity command uses.
+	assert.Equal(t, "https://auth.eu.kusari.cloud/", viper.GetString("auth-endpoint"))
+	assert.Equal(t, "https://auth.eu.kusari.cloud/", authEndpointFromConfig())
+}
+
+// Same hazard for "tenant" and "tenant-endpoint", which platform.go owns.
+func TestConnectivityDoesNotStealTenantBinding(t *testing.T) {
+	resetViper(t)
+
+	fresh := &cobra.Command{Use: "platform"}
+	fresh.PersistentFlags().String("tenant", "", "Tenant name")
+	require.NoError(t, viper.BindPFlag("tenant", fresh.PersistentFlags().Lookup("tenant")))
+	require.NoError(t, fresh.PersistentFlags().Set("tenant", "acme"))
+
+	assert.Equal(t, "acme", viper.GetString("tenant"))
+	assert.Equal(t, "acme", tenantFromConfig())
+}
+
+func TestTenantFromConfig(t *testing.T) {
+	t.Run("reads the tenant key", func(t *testing.T) {
+		resetViper(t)
+		viper.Set("tenant", "acme")
+		assert.Equal(t, "acme", tenantFromConfig())
+	})
+
+	t.Run("trims whitespace", func(t *testing.T) {
+		resetViper(t)
+		viper.Set("tenant", "  acme  ")
+		assert.Equal(t, "acme", tenantFromConfig())
+	})
+
+	// platform.go treats --tenant-endpoint as highest precedence, so a user who
+	// sets only that must still get the tenant-specific bucket probed.
+	t.Run("tenant-endpoint wins over tenant", func(t *testing.T) {
+		resetViper(t)
+		viper.Set("tenant", "acme")
+		viper.Set("tenant-endpoint", "https://demo.api.dev.kusari.cloud")
+		assert.Equal(t, "demo", tenantFromConfig())
+	})
+}
+
+func TestTenantFromEndpoint(t *testing.T) {
+	cases := map[string]string{
+		"https://demo.api.dev.kusari.cloud":     "demo",
+		"https://demo.api.us.kusari.cloud/":     "demo",
+		"demo.api.us.kusari.cloud":              "demo",
+		"https://demo.api.us.kusari.cloud:8443": "demo",
+		// No dot means no tenant label to take; guessing would be worse.
+		"https://localhost": "",
+		"":                  "",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, tenantFromEndpoint(in), "input %q", in)
+	}
+}
+
+// The connectivity command must not register any flag whose name collides with
+// a key another command has already bound to viper.
+func TestConnectivityCheckFlags(t *testing.T) {
+	cmd := connectivityCheck()
+
+	require.NotNil(t, cmd.Flags().Lookup("timeout"))
+	require.NotNil(t, cmd.Flags().Lookup("report"))
+
+	for _, owned := range []string{"auth-endpoint", "tenant", "tenant-endpoint", "client-id", "client-secret"} {
+		assert.Nil(t, cmd.Flags().Lookup(owned),
+			"%q is bound to viper by another command; declaring it here would hijack that binding", owned)
+	}
+
+	// No --proxy: proxy configuration comes from the environment so a passing
+	// check reflects what every other kusari command will do.
+	assert.Nil(t, cmd.Flags().Lookup("proxy"))
+	// No escape hatches that would weaken TLS verification.
+	assert.Nil(t, cmd.Flags().Lookup("insecure"))
+	assert.Nil(t, cmd.Flags().Lookup("ca-cert"))
+}
+
+func TestConnectivityCommandShape(t *testing.T) {
+	cmd := Connectivity()
+
+	assert.Equal(t, "connectivity", cmd.Name())
+	assert.ElementsMatch(t, []string{"conn", "net", "preflight"}, cmd.Aliases)
+
+	sub := cmd.Commands()
+	require.Len(t, sub, 1)
+	assert.Equal(t, "check", sub[0].Name())
+	assert.NotEmpty(t, sub[0].Long)
+	assert.NotEmpty(t, sub[0].Example)
+	assert.NotNil(t, sub[0].Args, "Args must be set explicitly")
+}
+
+func TestFormatDuration(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{266 * time.Millisecond, "266ms"},
+		{0, "0ms"},
+		{999 * time.Millisecond, "999ms"},
+		{time.Second, "1.000s"},
+		{1204 * time.Millisecond, "1.204s"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, formatDuration(c.in))
+	}
+}
+
+// A redirect Location can carry an OAuth state token. --verbose output gets
+// pasted into support tickets, so the query must be elided.
+func TestLocationForDisplayDropsQuery(t *testing.T) {
+	got := locationForDisplay("https://auth.us.kusari.cloud/oauth2/authorize?client_id=abc&state=SECRETSTATE")
+	assert.Equal(t, "https://auth.us.kusari.cloud/oauth2/authorize?…", got)
+	assert.NotContains(t, got, "SECRETSTATE")
+
+	assert.Equal(t, "https://aws.amazon.com/s3/", locationForDisplay("https://aws.amazon.com/s3/"))
+	// A relative or unparseable Location is passed through unchanged.
+	assert.Equal(t, "/login", locationForDisplay("/login"))
+}
+
+func TestOrNotSet(t *testing.T) {
+	assert.Equal(t, "(not set)", orNotSet(""))
+	assert.Equal(t, "http://p:8080", orNotSet("http://p:8080"))
+}
+
+func TestPrintWrappedRespectsWidth(t *testing.T) {
+	long := strings.Repeat("word ", 40)
+	out := captureStdout(t, func() { printWrapped("    1. ", long) })
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	require.Greater(t, len(lines), 1, "long text must wrap")
+	assert.True(t, strings.HasPrefix(lines[0], "    1. "))
+	for _, l := range lines[1:] {
+		assert.True(t, strings.HasPrefix(l, strings.Repeat(" ", len("    1. "))),
+			"continuation lines align under the prefix: %q", l)
+	}
+	for _, l := range lines {
+		assert.LessOrEqual(t, len(l), ruleWidth+len("    1. "))
+	}
+}

--- a/kusari/cmd/connectivity_check_test.go
+++ b/kusari/cmd/connectivity_check_test.go
@@ -95,57 +95,6 @@ func TestConnectivityDoesNotStealAuthEndpointBinding(t *testing.T) {
 	assert.Equal(t, "https://auth.eu.kusari.cloud/", authEndpointFromConfig())
 }
 
-// Same hazard for "tenant" and "tenant-endpoint", which platform.go owns.
-func TestConnectivityDoesNotStealTenantBinding(t *testing.T) {
-	resetViper(t)
-
-	fresh := &cobra.Command{Use: "platform"}
-	fresh.PersistentFlags().String("tenant", "", "Tenant name")
-	require.NoError(t, viper.BindPFlag("tenant", fresh.PersistentFlags().Lookup("tenant")))
-	require.NoError(t, fresh.PersistentFlags().Set("tenant", "acme"))
-
-	assert.Equal(t, "acme", viper.GetString("tenant"))
-	assert.Equal(t, "acme", tenantFromConfig())
-}
-
-func TestTenantFromConfig(t *testing.T) {
-	t.Run("reads the tenant key", func(t *testing.T) {
-		resetViper(t)
-		viper.Set("tenant", "acme")
-		assert.Equal(t, "acme", tenantFromConfig())
-	})
-
-	t.Run("trims whitespace", func(t *testing.T) {
-		resetViper(t)
-		viper.Set("tenant", "  acme  ")
-		assert.Equal(t, "acme", tenantFromConfig())
-	})
-
-	// platform.go treats --tenant-endpoint as highest precedence, so a user who
-	// sets only that must still get the tenant-specific bucket probed.
-	t.Run("tenant-endpoint wins over tenant", func(t *testing.T) {
-		resetViper(t)
-		viper.Set("tenant", "acme")
-		viper.Set("tenant-endpoint", "https://demo.api.dev.kusari.cloud")
-		assert.Equal(t, "demo", tenantFromConfig())
-	})
-}
-
-func TestTenantFromEndpoint(t *testing.T) {
-	cases := map[string]string{
-		"https://demo.api.dev.kusari.cloud":     "demo",
-		"https://demo.api.us.kusari.cloud/":     "demo",
-		"demo.api.us.kusari.cloud":              "demo",
-		"https://demo.api.us.kusari.cloud:8443": "demo",
-		// No dot means no tenant label to take; guessing would be worse.
-		"https://localhost": "",
-		"":                  "",
-	}
-	for in, want := range cases {
-		assert.Equal(t, want, tenantFromEndpoint(in), "input %q", in)
-	}
-}
-
 // The connectivity command must not register any flag whose name collides with
 // a key another command has already bound to viper.
 func TestConnectivityCheckFlags(t *testing.T) {

--- a/kusari/cmd/root.go
+++ b/kusari/cmd/root.go
@@ -142,6 +142,7 @@ func Execute() error {
 	rootCmd.AddCommand(Platform())
 	rootCmd.AddCommand(KusariConfiguration())
 	rootCmd.AddCommand(AI())
+	rootCmd.AddCommand(Connectivity())
 
 	return rootCmd.Execute()
 }

--- a/pkg/ai/auth.go
+++ b/pkg/ai/auth.go
@@ -10,13 +10,14 @@ import (
 	"strings"
 
 	"github.com/kusaridev/kusari-cli/v2/pkg/auth"
+	"github.com/kusaridev/kusari-cli/v2/pkg/constants"
 	"github.com/kusaridev/kusari-cli/v2/pkg/login"
 	"github.com/kusaridev/kusari-cli/v2/pkg/port"
 )
 
 const (
 	// Default auth configuration (matches CLI defaults)
-	defaultAuthEndpoint = "https://auth.us.kusari.cloud/"
+	defaultAuthEndpoint = constants.DefaultAuthURL
 	defaultClientID     = "4lnk6jccl3hc4lkcudai5lt36u"
 )
 

--- a/pkg/connectivity/classify.go
+++ b/pkg/connectivity/classify.go
@@ -1,0 +1,452 @@
+// Copyright (c) Kusari <https://www.kusari.dev/>
+// SPDX-License-Identifier: MIT
+
+package connectivity
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"syscall"
+)
+
+// Category is a stable, machine-readable classification of a probe outcome.
+type Category string
+
+const (
+	CategoryOK       Category = "ok"
+	CategoryDNS      Category = "dns"
+	CategoryTCP      Category = "tcp"
+	CategoryTLSTrust Category = "tls-trust"
+	CategoryTLSOther Category = "tls-other"
+	CategoryProxy    Category = "proxy"
+	CategoryTimeout  Category = "timeout"
+	CategoryUnknown  Category = "unknown"
+)
+
+// Diagnosis explains a probe failure in terms the user can act on.
+type Diagnosis struct {
+	Category    Category `json:"category"`
+	Summary     string   `json:"summary"`
+	Cause       string   `json:"cause,omitempty"`
+	Remediation []string `json:"remediation,omitempty"`
+	Raw         string   `json:"raw,omitempty"`
+}
+
+// ProxyConnectError reports a proxy that rejected CONNECT. net/http discards
+// the status code and returns only the reason phrase, so we capture it here.
+type ProxyConnectError struct {
+	ProxyHost   string
+	StatusCode  int
+	Status      string
+	AuthSchemes []string
+}
+
+func (e *ProxyConnectError) Error() string {
+	return fmt.Sprintf("proxy %s rejected CONNECT: %s", e.ProxyHost, e.Status)
+}
+
+// proxyConnectResponse runs before net/http's own 200-OK check, so an error
+// here only affects responses net/http was already going to reject.
+func proxyConnectResponse(_ context.Context, proxyURL *url.URL, _ *http.Request, res *http.Response) error {
+	if res.StatusCode >= 200 && res.StatusCode < 300 {
+		return nil
+	}
+	host := ""
+	if proxyURL != nil {
+		host = proxyURL.Host
+	}
+	return &ProxyConnectError{
+		ProxyHost:   host,
+		StatusCode:  res.StatusCode,
+		Status:      res.Status,
+		AuthSchemes: res.Header.Values("Proxy-Authenticate"),
+	}
+}
+
+// classifyCtx carries what Classify needs to write an accurate message. Proxy
+// is nil for a direct connection.
+type classifyCtx struct {
+	Host  string
+	Proxy *url.URL
+}
+
+// Classify turns a transport error into an actionable Diagnosis.
+//
+// Ordering matters: a proxyconnect failure wraps the same *net.DNSError and
+// *net.OpError as a direct failure, so it must match first or an unresolvable
+// proxy gets reported as an unresolvable Kusari endpoint.
+func Classify(cc classifyCtx, err error) Diagnosis {
+	if err == nil {
+		return Diagnosis{Category: CategoryOK}
+	}
+
+	// Proxy rejected CONNECT (407 and friends).
+	var pce *ProxyConnectError
+	if errors.As(err, &pce) {
+		return proxyRejectedDiagnosis(cc, pce, err)
+	}
+
+	// Failed while establishing the proxy tunnel.
+	if isProxyConnectOp(err) {
+		return proxyConnectDiagnosis(cc, err)
+	}
+
+	// Explicit deadlines here; *net.DNSError.IsTimeout stays with DNS below.
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, os.ErrDeadlineExceeded) {
+		return timeoutDiagnosis(cc, err)
+	}
+
+	if d, ok := tlsDiagnosis(cc, err); ok {
+		return d
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return dnsDiagnosis(cc, dnsErr, err)
+	}
+
+	if d, ok := tcpDiagnosis(cc, err); ok {
+		return d
+	}
+
+	// Remaining timeouts, e.g. net/http's unexported tlsHandshakeTimeoutError.
+	var nerr net.Error
+	if errors.As(err, &nerr) && nerr.Timeout() {
+		return timeoutDiagnosis(cc, err)
+	}
+
+	return Diagnosis{
+		Category: CategoryUnknown,
+		Summary:  "connection failed",
+		Cause:    fmt.Sprintf("could not reach %s: %v", cc.Host, err),
+		Remediation: []string{
+			"Re-run with --verbose to see the raw transport error.",
+			"Send the output of `kusari connectivity check --report report.json` to " + SupportEmail + ".",
+		},
+		Raw: err.Error(),
+	}
+}
+
+// isProxyConnectOp looks for any *net.OpError with Op == "proxyconnect".
+func isProxyConnectOp(err error) bool {
+	for e := err; e != nil; e = errors.Unwrap(e) {
+		var opErr *net.OpError
+		if errors.As(e, &opErr) {
+			if opErr.Op == "proxyconnect" {
+				return true
+			}
+			// Unwrap from inside the match, else errors.As keeps
+			// returning the same outermost OpError.
+			e = opErr
+		}
+	}
+	return false
+}
+
+func proxyRejectedDiagnosis(cc classifyCtx, pce *ProxyConnectError, err error) Diagnosis {
+	d := Diagnosis{
+		Category: CategoryProxy,
+		Summary:  fmt.Sprintf("proxy rejected the connection (HTTP %d)", pce.StatusCode),
+		Cause: fmt.Sprintf("proxy %q returned %q for CONNECT %s:443. "+
+			"The request never reached Kusari.", pce.ProxyHost, pce.Status, cc.Host),
+		Raw: err.Error(),
+	}
+	if pce.StatusCode == http.StatusProxyAuthRequired {
+		d.Remediation = []string{
+			"The proxy requires authentication. Include credentials in the proxy URL, " +
+				"e.g. HTTPS_PROXY=http://user:password@" + pce.ProxyHost,
+			"If your proxy uses Kerberos/NTLM, Go cannot negotiate it directly -- " +
+				"run a local authenticating proxy (cntlm, px) and point HTTPS_PROXY at that.",
+		}
+		if len(pce.AuthSchemes) > 0 {
+			d.Cause += fmt.Sprintf(" Proxy-Authenticate: %v.", pce.AuthSchemes)
+		}
+	} else {
+		d.Remediation = []string{
+			fmt.Sprintf("Ask your network team to allow CONNECT to %s:443 through %s.", cc.Host, pce.ProxyHost),
+			fmt.Sprintf("Confirm %s is spelled correctly in your proxy allowlist -- use the "+
+				"hostname, not an IP address.", cc.Host),
+		}
+	}
+	return d
+}
+
+func proxyConnectDiagnosis(cc classifyCtx, err error) Diagnosis {
+	proxyHost := "the configured proxy"
+	if cc.Proxy != nil {
+		proxyHost = cc.Proxy.Host
+	}
+
+	d := Diagnosis{
+		Category: CategoryProxy,
+		Summary:  "cannot reach the configured proxy",
+		Raw:      err.Error(),
+	}
+
+	// Be explicit that the hostname at fault is the proxy's, not Kusari's.
+	var dnsErr *net.DNSError
+	switch {
+	case errors.As(err, &dnsErr):
+		d.Cause = fmt.Sprintf("the proxy hostname %q does not resolve (%s). "+
+			"NOTE: %q is the PROXY hostname from your environment, not the Kusari endpoint.",
+			dnsErr.Name, dnsErr.Err, dnsErr.Name)
+	case errors.Is(err, syscall.ECONNREFUSED):
+		d.Cause = fmt.Sprintf("proxy %s refused the connection. "+
+			"NOTE: this is your PROXY, not the Kusari endpoint.", proxyHost)
+	default:
+		var cve *tls.CertificateVerificationError
+		if errors.As(err, &cve) {
+			d.Category = CategoryTLSTrust
+			d.Summary = "the proxy's own TLS certificate is not trusted"
+			d.Cause = fmt.Sprintf("proxy %s speaks HTTPS but presented a certificate "+
+				"this machine does not trust (%s).", proxyHost, issuerOf(cve))
+			d.Remediation = trustRemediation(issuerCN(cve), cc, proxyHost)
+			return d
+		}
+		d.Cause = fmt.Sprintf("failed to establish a tunnel through proxy %s to %s:443: %v. "+
+			"NOTE: the failure is at the PROXY, not at the Kusari endpoint.", proxyHost, cc.Host, err)
+	}
+
+	d.Remediation = []string{
+		fmt.Sprintf("Verify the proxy address %s is correct and reachable from this machine.", proxyHost),
+		"Check HTTP_PROXY / HTTPS_PROXY for typos; the value must be a URL such as http://host:port.",
+		fmt.Sprintf("If %s should bypass the proxy, add it to NO_PROXY.", cc.Host),
+	}
+	return d
+}
+
+func tlsDiagnosis(cc classifyCtx, err error) (Diagnosis, bool) {
+	var cve *tls.CertificateVerificationError
+	if !errors.As(err, &cve) {
+		// Certificate problems can also surface as bare x509 errors.
+		var ua x509.UnknownAuthorityError
+		if errors.As(err, &ua) {
+			return Diagnosis{
+				Category:    CategoryTLSTrust,
+				Summary:     "TLS certificate not trusted",
+				Cause:       fmt.Sprintf("%s presented a certificate chain terminating in a CA this machine does not trust.", cc.Host),
+				Remediation: trustRemediation("", cc, ""),
+				Raw:         err.Error(),
+			}, true
+		}
+		var rhe tls.RecordHeaderError
+		if errors.As(err, &rhe) {
+			return Diagnosis{
+				Category: CategoryTLSOther,
+				Summary:  "the server did not speak TLS",
+				Cause: fmt.Sprintf("%s answered the TLS handshake with something that is not TLS. "+
+					"A captive portal or a proxy that expects plain HTTP on 443 will do this.", cc.Host),
+				Remediation: []string{
+					"Confirm you are not behind a captive portal (open a browser and complete any sign-in).",
+					"Confirm the proxy, if any, supports HTTPS CONNECT tunnelling.",
+				},
+				Raw: err.Error(),
+			}, true
+		}
+		return Diagnosis{}, false
+	}
+
+	// Untrusted root (the corporate-proxy signature) needs a different fix
+	// than a hostname or validity problem.
+	var (
+		ua  x509.UnknownAuthorityError
+		he  x509.HostnameError
+		cie x509.CertificateInvalidError
+	)
+	switch {
+	case errors.As(cve.Err, &ua), errors.As(err, &ua):
+		return Diagnosis{
+			Category: CategoryTLSTrust,
+			Summary:  "TLS certificate not trusted",
+			Cause: fmt.Sprintf("%s presented a certificate chain that terminates in a CA this "+
+				"machine does not trust (%s). This is the signature of a TLS-inspecting proxy "+
+				"re-signing traffic.", cc.Host, issuerOf(cve)),
+			Remediation: trustRemediation(issuerCN(cve), cc, proxyHostOf(cc)),
+			Raw:         err.Error(),
+		}, true
+
+	case errors.As(cve.Err, &he), errors.As(err, &he):
+		return Diagnosis{
+			Category: CategoryTLSOther,
+			Summary:  "TLS certificate is not valid for this hostname",
+			Cause: fmt.Sprintf("the certificate presented for %s is issued for a different name (%s).",
+				cc.Host, cve.Err),
+			Remediation: []string{
+				fmt.Sprintf("Confirm %s is correct and that no proxy or DNS entry is redirecting it elsewhere.", cc.Host),
+				"If a TLS-inspecting proxy is in the path, its certificate must carry the correct SAN for this host.",
+			},
+			Raw: err.Error(),
+		}, true
+
+	case errors.As(cve.Err, &cie), errors.As(err, &cie):
+		return Diagnosis{
+			Category: CategoryTLSOther,
+			Summary:  "TLS certificate is invalid",
+			Cause:    fmt.Sprintf("the certificate presented for %s is not usable: %s.", cc.Host, cve.Err),
+			Remediation: []string{
+				"Check this machine's system clock -- a wrong date makes valid certificates look expired.",
+				"If a TLS-inspecting proxy is in the path, its certificate may have expired.",
+			},
+			Raw: err.Error(),
+		}, true
+	}
+
+	return Diagnosis{
+		Category:    CategoryTLSOther,
+		Summary:     "TLS handshake failed",
+		Cause:       fmt.Sprintf("could not complete the TLS handshake with %s: %s.", cc.Host, cve.Err),
+		Remediation: []string{"Re-run with --verbose for the raw TLS error."},
+		Raw:         err.Error(),
+	}, true
+}
+
+func dnsDiagnosis(cc classifyCtx, dnsErr *net.DNSError, err error) Diagnosis {
+	d := Diagnosis{Category: CategoryDNS, Raw: err.Error()}
+	switch {
+	case dnsErr.IsNotFound:
+		d.Summary = "DNS name does not exist"
+		d.Cause = fmt.Sprintf("%q returned no records (NXDOMAIN).", dnsErr.Name)
+	case dnsErr.IsTimeout:
+		d.Summary = "DNS lookup timed out"
+		d.Cause = fmt.Sprintf("no DNS server answered for %q in time.", dnsErr.Name)
+	default:
+		d.Summary = "DNS lookup failed"
+		d.Cause = fmt.Sprintf("could not resolve %q: %s.", dnsErr.Name, dnsErr.Err)
+	}
+	d.Remediation = []string{
+		fmt.Sprintf("Check %q for typos in the endpoint flag or KUSARI_* environment variable.", dnsErr.Name),
+		"On a split-horizon or VPN network the name may only resolve while connected to the VPN.",
+		fmt.Sprintf("Verify DNS resolution directly: nslookup %s", dnsErr.Name),
+	}
+	return d
+}
+
+func tcpDiagnosis(cc classifyCtx, err error) (Diagnosis, bool) {
+	var (
+		summary string
+		cause   string
+		fixes   []string
+	)
+
+	switch {
+	case errors.Is(err, syscall.ECONNREFUSED):
+		summary = "connection refused"
+		cause = fmt.Sprintf("%s:443 actively refused the connection.", cc.Host)
+		fixes = []string{
+			"Something answered but rejected the connection -- often a proxy or firewall on the path.",
+			fmt.Sprintf("Ask your network team to allow outbound TCP 443 to %s.", cc.Host),
+		}
+	case errors.Is(err, syscall.ECONNRESET):
+		summary = "connection reset"
+		cause = fmt.Sprintf("the connection to %s:443 was reset before completing.", cc.Host)
+		fixes = []string{
+			"A firewall or intrusion-prevention device commonly resets connections it blocks.",
+			fmt.Sprintf("Ask your network team whether TLS to %s is being terminated or dropped.", cc.Host),
+		}
+	case errors.Is(err, syscall.EHOSTUNREACH), errors.Is(err, syscall.ENETUNREACH):
+		summary = "host unreachable"
+		cause = fmt.Sprintf("no route to %s:443 from this machine.", cc.Host)
+		fixes = []string{
+			"Check that this machine has working internet access (or VPN, if required).",
+			"If egress requires a proxy, set HTTPS_PROXY.",
+		}
+	default:
+		var opErr *net.OpError
+		if !errors.As(err, &opErr) {
+			return Diagnosis{}, false
+		}
+		summary = "TCP connection failed"
+		cause = fmt.Sprintf("could not open a TCP connection to %s:443: %v.", cc.Host, opErr.Err)
+		fixes = []string{
+			fmt.Sprintf("Ask your network team to allow outbound TCP 443 to %s.", cc.Host),
+			"Re-run with --verbose for the raw transport error.",
+		}
+	}
+
+	return Diagnosis{
+		Category:    CategoryTCP,
+		Summary:     summary,
+		Cause:       cause,
+		Remediation: fixes,
+		Raw:         err.Error(),
+	}, true
+}
+
+func timeoutDiagnosis(cc classifyCtx, err error) Diagnosis {
+	cause := fmt.Sprintf("%s did not respond before the timeout elapsed.", cc.Host)
+	fixes := []string{
+		"Re-run with a longer timeout, e.g. --timeout 30s.",
+		fmt.Sprintf("A silent drop (no refusal, no reset) usually means a firewall is blackholing traffic to %s:443.", cc.Host),
+	}
+	if cc.Proxy != nil {
+		fixes = append(fixes, fmt.Sprintf("Traffic is routed through proxy %s; confirm that proxy can reach %s.",
+			cc.Proxy.Host, cc.Host))
+	}
+	return Diagnosis{
+		Category:    CategoryTimeout,
+		Summary:     "connection timed out",
+		Cause:       cause,
+		Remediation: fixes,
+		Raw:         err.Error(),
+	}
+}
+
+// trustRemediation returns OS-specific CA install steps. issuerCN may be empty.
+func trustRemediation(issuerCN string, cc classifyCtx, proxyHost string) []string {
+	name := "your corporate root CA"
+	if issuerCN != "" {
+		name = fmt.Sprintf("%q", issuerCN)
+	}
+
+	fixes := []string{
+		fmt.Sprintf("Install the CA certificate %s into this machine's system trust store.", name),
+		"macOS: add the CA to the System keychain and mark it 'Always Trust'. Go uses the macOS " +
+			"platform verifier, so SSL_CERT_FILE is IGNORED on macOS.",
+		"Linux: copy the CA PEM into /usr/local/share/ca-certificates/ and run `update-ca-certificates`, " +
+			"or set SSL_CERT_FILE=/path/to/ca-bundle.pem.",
+		"Windows: import the CA into the Local Machine 'Trusted Root Certification Authorities' store.",
+	}
+	if proxyHost != "" {
+		fixes = append(fixes, fmt.Sprintf("Traffic to %s:443 goes through proxy %s, which is terminating TLS, "+
+			"so that proxy's CA must be trusted. Alternatively add %s to NO_PROXY.", cc.Host, proxyHost, cc.Host))
+	}
+	return append(fixes, "The Kusari CLI intentionally provides no --insecure or --ca-cert flag: trust must be "+
+		"configured at the OS level so every tool on this machine behaves consistently.")
+}
+
+// issuerCN names the untrusted authority, or "" if undeterminable.
+func issuerCN(cve *tls.CertificateVerificationError) string {
+	if cve == nil || len(cve.UnverifiedCertificates) == 0 {
+		return ""
+	}
+	// The last cert sent is closest to the root, so it names the authority.
+	last := cve.UnverifiedCertificates[len(cve.UnverifiedCertificates)-1]
+	if last.Issuer.CommonName != "" {
+		return last.Issuer.CommonName
+	}
+	if len(last.Issuer.Organization) > 0 {
+		return last.Issuer.Organization[0]
+	}
+	return ""
+}
+
+func issuerOf(cve *tls.CertificateVerificationError) string {
+	if cn := issuerCN(cve); cn != "" {
+		return fmt.Sprintf("issuer: %q", cn)
+	}
+	return "issuer could not be determined"
+}
+
+func proxyHostOf(cc classifyCtx) string {
+	if cc.Proxy == nil {
+		return ""
+	}
+	return cc.Proxy.Host
+}

--- a/pkg/connectivity/classify_test.go
+++ b/pkg/connectivity/classify_test.go
@@ -1,0 +1,333 @@
+// Copyright (c) Kusari <https://www.kusari.dev/>
+// SPDX-License-Identifier: MIT
+
+package connectivity
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}
+
+// wrapGet mimics how http.Client wraps transport errors.
+func wrapGet(inner error) error {
+	return &url.Error{Op: "Get", URL: "https://platform.api.us.kusari.cloud/user", Err: inner}
+}
+
+// dialErr builds the chain http.Client -> *url.Error -> *net.OpError{dial}.
+func dialErr(inner error) error {
+	return wrapGet(&net.OpError{Op: "dial", Net: "tcp", Err: inner})
+}
+
+// proxyConnectErr builds the chain net/http uses when tunnel setup fails:
+// *url.Error -> *net.OpError{proxyconnect} -> inner.
+func proxyConnectErr(inner error) error {
+	return wrapGet(&net.OpError{Op: "proxyconnect", Net: "tcp", Err: inner})
+}
+
+func syscallErr(errno syscall.Errno) error {
+	return os.NewSyscallError("connect", errno)
+}
+
+// certVerifyErr builds a *tls.CertificateVerificationError carrying a chain
+// whose root names the given issuer, as a TLS-inspecting proxy would.
+func certVerifyErr(issuer string, inner error) error {
+	leaf := &x509.Certificate{
+		Subject: pkix.Name{CommonName: "*.us.kusari.cloud"},
+		Issuer:  pkix.Name{CommonName: issuer},
+	}
+	return wrapGet(&tls.CertificateVerificationError{
+		UnverifiedCertificates: []*x509.Certificate{leaf},
+		Err:                    inner,
+	})
+}
+
+func TestClassify(t *testing.T) {
+	proxy := mustURL(t, "http://proxy.corp.example:8080")
+
+	cases := []struct {
+		name         string
+		cc           classifyCtx
+		err          error
+		wantCategory Category
+		wantInCause  string
+	}{
+		{
+			name:         "nil error is ok",
+			err:          nil,
+			wantCategory: CategoryOK,
+		},
+		{
+			name:         "dns nxdomain",
+			cc:           classifyCtx{Host: "platform.api.us.kusari.cloud"},
+			err:          dialErr(&net.DNSError{Err: "no such host", Name: "platform.api.us.kusari.cloud", IsNotFound: true}),
+			wantCategory: CategoryDNS,
+			wantInCause:  "NXDOMAIN",
+		},
+		{
+			name:         "dns timeout",
+			cc:           classifyCtx{Host: "platform.api.us.kusari.cloud"},
+			err:          dialErr(&net.DNSError{Err: "i/o timeout", Name: "platform.api.us.kusari.cloud", IsTimeout: true}),
+			wantCategory: CategoryDNS,
+			wantInCause:  "no DNS server answered",
+		},
+		{
+			name:         "dns other",
+			cc:           classifyCtx{Host: "platform.api.us.kusari.cloud"},
+			err:          dialErr(&net.DNSError{Err: "server misbehaving", Name: "platform.api.us.kusari.cloud"}),
+			wantCategory: CategoryDNS,
+			wantInCause:  "server misbehaving",
+		},
+		{
+			name:         "tcp connection refused",
+			cc:           classifyCtx{Host: "platform.api.us.kusari.cloud"},
+			err:          dialErr(syscallErr(syscall.ECONNREFUSED)),
+			wantCategory: CategoryTCP,
+			wantInCause:  "actively refused",
+		},
+		{
+			name:         "tcp connection reset",
+			cc:           classifyCtx{Host: "platform.api.us.kusari.cloud"},
+			err:          dialErr(syscallErr(syscall.ECONNRESET)),
+			wantCategory: CategoryTCP,
+			wantInCause:  "was reset",
+		},
+		{
+			name:         "tcp host unreachable",
+			cc:           classifyCtx{Host: "platform.api.us.kusari.cloud"},
+			err:          dialErr(syscallErr(syscall.EHOSTUNREACH)),
+			wantCategory: CategoryTCP,
+			wantInCause:  "no route",
+		},
+		{
+			name:         "tcp network unreachable",
+			cc:           classifyCtx{Host: "platform.api.us.kusari.cloud"},
+			err:          dialErr(syscallErr(syscall.ENETUNREACH)),
+			wantCategory: CategoryTCP,
+			wantInCause:  "no route",
+		},
+		{
+			name:         "tcp generic op error",
+			cc:           classifyCtx{Host: "platform.api.us.kusari.cloud"},
+			err:          dialErr(errors.New("some dial failure")),
+			wantCategory: CategoryTCP,
+			wantInCause:  "could not open a TCP connection",
+		},
+		{
+			name:         "tls untrusted authority names the issuer",
+			cc:           classifyCtx{Host: "platform.api.us.kusari.cloud", Proxy: proxy},
+			err:          certVerifyErr("ACME Corp TLS Inspection CA", x509.UnknownAuthorityError{}),
+			wantCategory: CategoryTLSTrust,
+			wantInCause:  `issuer: "ACME Corp TLS Inspection CA"`,
+		},
+		{
+			name:         "bare unknown authority error",
+			cc:           classifyCtx{Host: "platform.api.us.kusari.cloud"},
+			err:          wrapGet(x509.UnknownAuthorityError{}),
+			wantCategory: CategoryTLSTrust,
+			wantInCause:  "does not trust",
+		},
+		{
+			name:         "tls hostname mismatch",
+			cc:           classifyCtx{Host: "platform.api.us.kusari.cloud"},
+			err:          certVerifyErr("Some CA", x509.HostnameError{Host: "platform.api.us.kusari.cloud"}),
+			wantCategory: CategoryTLSOther,
+			wantInCause:  "issued for a different name",
+		},
+		{
+			name:         "tls certificate expired",
+			cc:           classifyCtx{Host: "platform.api.us.kusari.cloud"},
+			err:          certVerifyErr("Some CA", x509.CertificateInvalidError{Reason: x509.Expired}),
+			wantCategory: CategoryTLSOther,
+			wantInCause:  "not usable",
+		},
+		{
+			name:         "server did not speak tls",
+			cc:           classifyCtx{Host: "platform.api.us.kusari.cloud"},
+			err:          wrapGet(tls.RecordHeaderError{Msg: "first record does not look like a TLS handshake"}),
+			wantCategory: CategoryTLSOther,
+			wantInCause:  "not TLS",
+		},
+		{
+			name:         "context deadline exceeded",
+			cc:           classifyCtx{Host: "platform.api.us.kusari.cloud", Proxy: proxy},
+			err:          wrapGet(context.DeadlineExceeded),
+			wantCategory: CategoryTimeout,
+			wantInCause:  "did not respond before the timeout",
+		},
+		{
+			name:         "os deadline exceeded",
+			cc:           classifyCtx{Host: "platform.api.us.kusari.cloud"},
+			err:          wrapGet(os.ErrDeadlineExceeded),
+			wantCategory: CategoryTimeout,
+			wantInCause:  "did not respond before the timeout",
+		},
+		{
+			name:         "unknown error",
+			cc:           classifyCtx{Host: "platform.api.us.kusari.cloud"},
+			err:          wrapGet(errors.New("something exotic")),
+			wantCategory: CategoryUnknown,
+			wantInCause:  "something exotic",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Classify(c.cc, c.err)
+			assert.Equal(t, c.wantCategory, got.Category)
+			if c.wantInCause != "" {
+				assert.Contains(t, got.Cause, c.wantInCause)
+			}
+			if c.wantCategory != CategoryOK {
+				assert.NotEmpty(t, got.Summary, "every failure needs a summary")
+				assert.NotEmpty(t, got.Remediation, "every failure needs at least one remediation step")
+				assert.NotEmpty(t, got.Raw, "raw error must be retained for --verbose")
+			}
+		})
+	}
+}
+
+// A proxyconnect failure wraps exactly the same error types as a direct
+// failure. If ordering regressed, these would be reported as dns/tcp against
+// the Kusari hostname -- sending the user to fix the wrong thing.
+func TestClassifyProxyConnectTakesPrecedence(t *testing.T) {
+	proxy := mustURL(t, "http://proxy.corp.example:8080")
+	cc := classifyCtx{Host: "platform.api.us.kusari.cloud", Proxy: proxy}
+
+	t.Run("unresolvable proxy is proxy, not dns", func(t *testing.T) {
+		err := proxyConnectErr(&net.OpError{Op: "dial", Net: "tcp",
+			Err: &net.DNSError{Err: "no such host", Name: "proxy.corp.example", IsNotFound: true}})
+
+		got := Classify(cc, err)
+		assert.Equal(t, CategoryProxy, got.Category)
+		assert.Contains(t, got.Cause, "proxy.corp.example")
+		assert.Contains(t, got.Cause, "is the PROXY hostname")
+		// It must not blame the Kusari endpoint.
+		assert.NotContains(t, got.Summary, "platform.api.us.kusari.cloud")
+	})
+
+	t.Run("refused proxy is proxy, not tcp", func(t *testing.T) {
+		err := proxyConnectErr(&net.OpError{Op: "dial", Net: "tcp", Err: syscallErr(syscall.ECONNREFUSED)})
+
+		got := Classify(cc, err)
+		assert.Equal(t, CategoryProxy, got.Category)
+		assert.Contains(t, got.Cause, "this is your PROXY")
+	})
+
+	t.Run("untrusted https proxy cert is tls-trust with proxy context", func(t *testing.T) {
+		err := wrapGet(&net.OpError{Op: "proxyconnect", Net: "tcp",
+			Err: &tls.CertificateVerificationError{
+				UnverifiedCertificates: []*x509.Certificate{{
+					Subject: pkix.Name{CommonName: "proxy.corp.example"},
+					Issuer:  pkix.Name{CommonName: "Corp Proxy Root"},
+				}},
+				Err: x509.UnknownAuthorityError{},
+			}})
+
+		got := Classify(cc, err)
+		assert.Equal(t, CategoryTLSTrust, got.Category)
+		assert.Contains(t, got.Cause, "proxy.corp.example:8080")
+		assert.Contains(t, got.Cause, `issuer: "Corp Proxy Root"`)
+	})
+}
+
+func TestClassifyProxyRejectedConnect(t *testing.T) {
+	cc := classifyCtx{Host: "platform.api.us.kusari.cloud",
+		Proxy: mustURL(t, "http://proxy.corp.example:8080")}
+
+	t.Run("407 explains proxy auth", func(t *testing.T) {
+		err := wrapGet(&ProxyConnectError{
+			ProxyHost:   "proxy.corp.example:8080",
+			StatusCode:  http.StatusProxyAuthRequired,
+			Status:      "407 Proxy Authentication Required",
+			AuthSchemes: []string{"Negotiate", "Basic realm=\"corp\""},
+		})
+
+		got := Classify(cc, err)
+		assert.Equal(t, CategoryProxy, got.Category)
+		assert.Contains(t, got.Summary, "407")
+		assert.Contains(t, got.Cause, "Proxy-Authenticate")
+		assert.Contains(t, strings.Join(got.Remediation, "\n"), "requires authentication")
+	})
+
+	t.Run("403 explains allowlist", func(t *testing.T) {
+		err := wrapGet(&ProxyConnectError{
+			ProxyHost:  "proxy.corp.example:8080",
+			StatusCode: http.StatusForbidden,
+			Status:     "403 Forbidden",
+		})
+
+		got := Classify(cc, err)
+		assert.Equal(t, CategoryProxy, got.Category)
+		assert.Contains(t, strings.Join(got.Remediation, "\n"), "allow CONNECT")
+	})
+}
+
+func TestProxyConnectResponseHook(t *testing.T) {
+	proxy := mustURL(t, "http://proxy.corp.example:8080")
+
+	t.Run("2xx is not an error", func(t *testing.T) {
+		err := proxyConnectResponse(context.Background(), proxy, nil,
+			&http.Response{StatusCode: 200, Status: "200 OK", Header: http.Header{}})
+		assert.NoError(t, err)
+	})
+
+	t.Run("407 becomes a typed error carrying the status", func(t *testing.T) {
+		res := &http.Response{
+			StatusCode: 407,
+			Status:     "407 Proxy Authentication Required",
+			Header:     http.Header{"Proxy-Authenticate": []string{"Basic"}},
+		}
+		err := proxyConnectResponse(context.Background(), proxy, nil, res)
+		require.Error(t, err)
+
+		var pce *ProxyConnectError
+		require.ErrorAs(t, err, &pce)
+		assert.Equal(t, 407, pce.StatusCode)
+		assert.Equal(t, "proxy.corp.example:8080", pce.ProxyHost)
+		assert.Equal(t, []string{"Basic"}, pce.AuthSchemes)
+	})
+}
+
+func TestTrustRemediationIsPlatformSpecific(t *testing.T) {
+	fixes := strings.Join(trustRemediation("Corp CA", classifyCtx{Host: "h"}, "p:8080"), "\n")
+
+	assert.Contains(t, fixes, `"Corp CA"`)
+	// The macOS caveat is the whole reason this text exists: SSL_CERT_FILE is
+	// silently ignored there, so telling a Mac user to set it would be wrong.
+	assert.Contains(t, fixes, "IGNORED on macOS")
+	assert.Contains(t, fixes, "update-ca-certificates")
+	assert.Contains(t, fixes, "NO_PROXY")
+	assert.Contains(t, fixes, "no --insecure")
+}
+
+func TestIssuerCNFallsBackToOrganization(t *testing.T) {
+	cve := &tls.CertificateVerificationError{
+		UnverifiedCertificates: []*x509.Certificate{{
+			Issuer: pkix.Name{Organization: []string{"Example Corp"}},
+		}},
+	}
+	assert.Equal(t, "Example Corp", issuerCN(cve))
+
+	assert.Empty(t, issuerCN(nil))
+	assert.Empty(t, issuerCN(&tls.CertificateVerificationError{}))
+}

--- a/pkg/connectivity/connectivity.go
+++ b/pkg/connectivity/connectivity.go
@@ -104,11 +104,15 @@ func (o Options) withDefaults() Options {
 	return o
 }
 
-// DefaultTargets returns the endpoints to probe, in display order. The SBOM
-// upload bucket is tenant-specific, so it is omitted when no tenant is known
-// rather than guessed at.
+// DefaultTargets returns the endpoints to probe, in display order.
+//
+// Only one S3 bucket hostname is probed: S3 uses wildcard DNS and serves the
+// same *.s3.<region>.amazonaws.com certificate for every bucket, so DNS, TCP,
+// TLS and proxy egress verified against one bucket hold for all of them. The
+// tenant-specific SBOM bucket still appears in AllowlistHosts for proxies that
+// filter by exact hostname.
 func DefaultTargets(e Endpoints) []Target {
-	targets := []Target{
+	return []Target{
 		{
 			Name:    "auth",
 			Purpose: "Authentication service (OAuth2)",
@@ -124,32 +128,34 @@ func DefaultTargets(e Endpoints) []Target {
 			Purpose: "Console UI (web application)",
 			URL:     joinURL(e.ConsoleURL, ""),
 		},
+		{
+			Name:    "upload",
+			Purpose: "Artifact upload (AWS S3)",
+			URL: "https://" + fmt.Sprintf(constants.InspectorUploadHostPattern,
+				constants.DefaultUploadEnv, constants.DefaultS3Region, constants.DefaultS3Region),
+		},
 	}
-
-	if e.Tenant != "" {
-		targets = append(targets, Target{
-			Name:    "upload-sbom",
-			Purpose: "SBOM artifact upload (AWS S3)",
-			URL: "https://" + fmt.Sprintf(constants.SBOMUploadHostPattern,
-				constants.DefaultUploadEnv, constants.DefaultS3Region, e.Tenant, constants.DefaultS3Region),
-		})
-	}
-
-	return append(targets, Target{
-		Name:    "upload-scan",
-		Purpose: "Repository scan bundle upload (AWS S3)",
-		URL: "https://" + fmt.Sprintf(constants.InspectorUploadHostPattern,
-			constants.DefaultUploadEnv, constants.DefaultS3Region, constants.DefaultS3Region),
-	})
 }
 
-// AllowlistHosts returns the hostnames behind targets, for the network team.
-func AllowlistHosts(targets []Target) []AllowlistHost {
-	hosts := make([]AllowlistHost, 0, len(targets))
+// AllowlistHosts returns every hostname to allow through a firewall or proxy:
+// the probed targets plus the tenant-specific SBOM upload bucket, which is not
+// probed (see DefaultTargets) but still needed by proxies that filter on exact
+// hostnames. When no tenant is known, a <tenant> placeholder is rendered.
+func AllowlistHosts(e Endpoints, targets []Target) []AllowlistHost {
+	hosts := make([]AllowlistHost, 0, len(targets)+1)
 	for _, t := range targets {
 		hosts = append(hosts, AllowlistHost{Host: hostOf(t.URL), Purpose: t.Purpose})
 	}
-	return hosts
+
+	tenant := e.Tenant
+	if tenant == "" {
+		tenant = "<tenant>"
+	}
+	return append(hosts, AllowlistHost{
+		Host: fmt.Sprintf(constants.SBOMUploadHostPattern,
+			constants.DefaultUploadEnv, constants.DefaultS3Region, tenant, constants.DefaultS3Region),
+		Purpose: "SBOM artifact upload (AWS S3)",
+	})
 }
 
 // Check probes every target concurrently and returns results in target order.

--- a/pkg/connectivity/connectivity.go
+++ b/pkg/connectivity/connectivity.go
@@ -1,0 +1,324 @@
+// Copyright (c) Kusari <https://www.kusari.dev/>
+// SPDX-License-Identifier: MIT
+
+// Package connectivity probes the network path between this machine and the
+// endpoints the Kusari CLI needs.
+//
+// Proxy configuration comes only from HTTP_PROXY/HTTPS_PROXY/NO_PROXY via
+// http.ProxyFromEnvironment, so a passing check reflects what every other
+// client in this CLI will do. There is deliberately no proxy flag.
+package connectivity
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kusaridev/kusari-cli/v2/pkg/constants"
+)
+
+const (
+	DefaultTimeout = 10 * time.Second
+	SupportEmail   = "support@kusari.cloud"
+
+	maxBodyRead = 4 << 10
+)
+
+// Target is one endpoint to probe.
+type Target struct {
+	Name    string
+	Purpose string
+	URL     string
+}
+
+// TLSInfo records what the peer presented. Captured on success too: it reveals
+// a trusted interception CA that would otherwise go unnoticed.
+type TLSInfo struct {
+	Version       string `json:"version"`
+	CipherSuite   string `json:"cipherSuite"`
+	PeerSubjectCN string `json:"peerSubjectCN,omitempty"`
+	PeerIssuerCN  string `json:"peerIssuerCN,omitempty"`
+}
+
+// Result is the outcome of probing one Target.
+type Result struct {
+	Target     Target
+	Proxy      *url.URL
+	StatusCode int
+	Status     string
+	Location   string
+	Duration   time.Duration
+	TLS        *TLSInfo
+	Diag       Diagnosis
+	Err        error
+}
+
+// OK reports whether the endpoint is reachable: the TLS handshake completed and
+// an HTTP status came back. 401, 403, 404, 3xx and 5xx all count.
+func (r Result) OK() bool { return r.Err == nil }
+
+// ServiceError reports a 5xx: reachable, but the fault is Kusari's rather than
+// the user's network.
+func (r Result) ServiceError() bool { return r.OK() && r.StatusCode >= 500 }
+
+// AllowlistHost is a hostname a firewall or proxy allowlist needs.
+type AllowlistHost struct {
+	Host    string `json:"host"`
+	Purpose string `json:"purpose"`
+}
+
+// Endpoints holds the resolved base URLs to probe.
+type Endpoints struct {
+	AuthURL     string
+	PlatformURL string
+	ConsoleURL  string
+	Tenant      string
+}
+
+// Options configures a Check run.
+type Options struct {
+	Timeout time.Duration
+	// ProxyResolver defaults to http.ProxyFromEnvironment. Injectable because
+	// net/http caches the proxy env behind a sync.Once, which makes
+	// env-mutating tests order-dependent.
+	ProxyResolver func(*http.Request) (*url.URL, error)
+	UserAgent     string
+}
+
+func (o Options) withDefaults() Options {
+	if o.Timeout <= 0 {
+		o.Timeout = DefaultTimeout
+	}
+	if o.ProxyResolver == nil {
+		o.ProxyResolver = http.ProxyFromEnvironment
+	}
+	if o.UserAgent == "" {
+		o.UserAgent = "kusari-cli/connectivity-check"
+	}
+	return o
+}
+
+// DefaultTargets returns the endpoints to probe, in display order. The SBOM
+// upload bucket is tenant-specific, so it is omitted when no tenant is known
+// rather than guessed at.
+func DefaultTargets(e Endpoints) []Target {
+	targets := []Target{
+		{
+			Name:    "auth",
+			Purpose: "Authentication service (OAuth2)",
+			URL:     joinURL(e.AuthURL, "oauth2/token"),
+		},
+		{
+			Name:    "platform",
+			Purpose: "Platform API",
+			URL:     joinURL(e.PlatformURL, "user"),
+		},
+		{
+			Name:    "console",
+			Purpose: "Console UI (web application)",
+			URL:     joinURL(e.ConsoleURL, ""),
+		},
+	}
+
+	if e.Tenant != "" {
+		targets = append(targets, Target{
+			Name:    "upload-sbom",
+			Purpose: "SBOM artifact upload (AWS S3)",
+			URL: "https://" + fmt.Sprintf(constants.SBOMUploadHostPattern,
+				constants.DefaultUploadEnv, constants.DefaultS3Region, e.Tenant, constants.DefaultS3Region),
+		})
+	}
+
+	return append(targets, Target{
+		Name:    "upload-scan",
+		Purpose: "Repository scan bundle upload (AWS S3)",
+		URL: "https://" + fmt.Sprintf(constants.InspectorUploadHostPattern,
+			constants.DefaultUploadEnv, constants.DefaultS3Region, constants.DefaultS3Region),
+	})
+}
+
+// AllowlistHosts returns the hostnames behind targets, for the network team.
+func AllowlistHosts(targets []Target) []AllowlistHost {
+	hosts := make([]AllowlistHost, 0, len(targets))
+	for _, t := range targets {
+		hosts = append(hosts, AllowlistHost{Host: hostOf(t.URL), Purpose: t.Purpose})
+	}
+	return hosts
+}
+
+// Check probes every target concurrently and returns results in target order.
+// Every failure is reported as a Result, so Check returns no error.
+func Check(ctx context.Context, targets []Target, opts Options) []Result {
+	opts = opts.withDefaults()
+
+	client := &http.Client{
+		Transport: newTransport(),
+		// Never follow redirects: doing so would report a status from a host we
+		// did not intend to probe and could mask a failure at the real endpoint.
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	defer client.CloseIdleConnections()
+
+	results := make([]Result, len(targets))
+	var wg sync.WaitGroup
+	for i, t := range targets {
+		wg.Add(1)
+		go func(i int, t Target) {
+			defer wg.Done()
+			results[i] = probe(ctx, client, opts, t)
+		}(i, t)
+	}
+	wg.Wait()
+	return results
+}
+
+// newTransport clones http.DefaultTransport so probes negotiate exactly what
+// the rest of the CLI negotiates. A hand-built &http.Transport{} would silently
+// lose proxy support, HTTP/2 and every default timeout.
+func newTransport() *http.Transport {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+
+	// net/http discards the CONNECT status code and returns only the reason
+	// phrase, so capture the response to turn a 407 into a typed error.
+	tr.OnProxyConnectResponse = proxyConnectResponse
+
+	// Each target needs a fresh DNS -> TCP -> TLS path.
+	tr.DisableKeepAlives = true
+
+	// TLSClientConfig stays nil: system roots, verification on.
+	return tr
+}
+
+func probe(ctx context.Context, client *http.Client, opts Options, t Target) Result {
+	res := Result{Target: t}
+	cc := classifyCtx{Host: hostOf(t.URL)}
+
+	// Resolve the proxy first so a failure can still name it.
+	proxy, err := resolveProxy(opts.ProxyResolver, t.URL)
+	if err != nil {
+		res.Err = err
+		res.Diag = Diagnosis{
+			Category: CategoryProxy,
+			Summary:  "invalid proxy configuration",
+			Cause: fmt.Sprintf("the proxy environment variable that applies to %s is not usable: %v",
+				t.URL, err),
+			Remediation: []string{
+				"HTTP_PROXY / HTTPS_PROXY must be a URL such as http://host:port.",
+			},
+			Raw: err.Error(),
+		}
+		return res
+	}
+	res.Proxy = proxy
+	cc.Proxy = proxy
+
+	// A context deadline surfaces as context.DeadlineExceeded, which Classify
+	// can match, and it honours cancellation of the parent context.
+	rctx, cancel := context.WithTimeout(ctx, opts.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(rctx, http.MethodGet, t.URL, nil)
+	if err != nil {
+		res.Err = err
+		res.Diag = Diagnosis{
+			Category: CategoryUnknown,
+			Summary:  "invalid target URL",
+			Cause:    fmt.Sprintf("%q is not a valid URL: %v", t.URL, err),
+			Raw:      err.Error(),
+		}
+		return res
+	}
+	req.Header.Set("User-Agent", opts.UserAgent)
+
+	start := time.Now()
+	resp, err := client.Do(req)
+	res.Duration = time.Since(start)
+	if err != nil {
+		res.Err = err
+		res.Diag = Classify(cc, err)
+		return res
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxBodyRead))
+
+	res.StatusCode = resp.StatusCode
+	res.Status = resp.Status
+	res.Location = resp.Header.Get("Location")
+	if resp.TLS != nil {
+		res.TLS = tlsInfo(resp.TLS)
+	}
+	res.Diag = Diagnosis{Category: CategoryOK}
+	return res
+}
+
+// resolveProxy reports which proxy the resolver picks for rawURL. Using the
+// same function the transport uses guarantees the reported proxy is the one
+// actually used, including NO_PROXY and loopback rules.
+func resolveProxy(resolver func(*http.Request) (*url.URL, error), rawURL string) (*url.URL, error) {
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	return resolver(req)
+}
+
+func tlsInfo(cs *tls.ConnectionState) *TLSInfo {
+	i := &TLSInfo{
+		Version:     tls.VersionName(cs.Version),
+		CipherSuite: tls.CipherSuiteName(cs.CipherSuite),
+	}
+	if len(cs.PeerCertificates) > 0 {
+		leaf := cs.PeerCertificates[0]
+		i.PeerSubjectCN = leaf.Subject.CommonName
+		i.PeerIssuerCN = leaf.Issuer.CommonName
+	}
+	return i
+}
+
+// joinURL appends path to base with exactly one separating slash, dropping any
+// query or fragment on base. Naive concatenation would append after the query,
+// probing the wrong path, and would copy a credential-bearing base URL into the
+// report.
+func joinURL(base, path string) string {
+	base = strings.TrimSpace(base)
+	u, err := url.Parse(base)
+	if err != nil || u.Host == "" {
+		return strings.TrimSuffix(base, "/") + "/" + strings.TrimPrefix(path, "/")
+	}
+	u.RawQuery = ""
+	u.ForceQuery = false
+	u.Fragment = ""
+	u.User = nil
+	u.Path = strings.TrimSuffix(u.Path, "/") + "/" + strings.TrimPrefix(path, "/")
+	return u.String()
+}
+
+func hostOf(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return rawURL
+	}
+	return u.Hostname()
+}
+
+// ProxyLabel renders a proxy as host only, never credentials.
+func ProxyLabel(u *url.URL) string {
+	if u == nil {
+		return "direct"
+	}
+	return u.Host
+}
+
+// ProxySummary renders a proxy URL with any password replaced.
+func ProxySummary(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	return u.Redacted()
+}

--- a/pkg/connectivity/connectivity.go
+++ b/pkg/connectivity/connectivity.go
@@ -35,6 +35,9 @@ type Target struct {
 	Name    string
 	Purpose string
 	URL     string
+	// AllowAs, when set, replaces the URL's hostname in the allowlist output --
+	// e.g. a wildcard covering every bucket on a shared S3 endpoint.
+	AllowAs string
 }
 
 // TLSInfo records what the peer presented. Captured on success too: it reveals
@@ -78,7 +81,6 @@ type Endpoints struct {
 	AuthURL     string
 	PlatformURL string
 	ConsoleURL  string
-	Tenant      string
 }
 
 // Options configures a Check run.
@@ -109,8 +111,8 @@ func (o Options) withDefaults() Options {
 // Only one S3 bucket hostname is probed: S3 uses wildcard DNS and serves the
 // same *.s3.<region>.amazonaws.com certificate for every bucket, so DNS, TCP,
 // TLS and proxy egress verified against one bucket hold for all of them. The
-// tenant-specific SBOM bucket still appears in AllowlistHosts for proxies that
-// filter by exact hostname.
+// allowlist advertises the wildcard so proxy rules cover every upload bucket,
+// including the tenant-specific ones.
 func DefaultTargets(e Endpoints) []Target {
 	return []Target{
 		{
@@ -130,32 +132,25 @@ func DefaultTargets(e Endpoints) []Target {
 		},
 		{
 			Name:    "upload",
-			Purpose: "Artifact upload (AWS S3)",
+			Purpose: "Artifact uploads (AWS S3)",
 			URL: "https://" + fmt.Sprintf(constants.InspectorUploadHostPattern,
 				constants.DefaultUploadEnv, constants.DefaultS3Region, constants.DefaultS3Region),
+			AllowAs: "*.s3." + constants.DefaultS3Region + ".amazonaws.com",
 		},
 	}
 }
 
-// AllowlistHosts returns every hostname to allow through a firewall or proxy:
-// the probed targets plus the tenant-specific SBOM upload bucket, which is not
-// probed (see DefaultTargets) but still needed by proxies that filter on exact
-// hostnames. When no tenant is known, a <tenant> placeholder is rendered.
-func AllowlistHosts(e Endpoints, targets []Target) []AllowlistHost {
-	hosts := make([]AllowlistHost, 0, len(targets)+1)
+// AllowlistHosts returns the hostnames to allow through a firewall or proxy.
+func AllowlistHosts(targets []Target) []AllowlistHost {
+	hosts := make([]AllowlistHost, 0, len(targets))
 	for _, t := range targets {
-		hosts = append(hosts, AllowlistHost{Host: hostOf(t.URL), Purpose: t.Purpose})
+		host := t.AllowAs
+		if host == "" {
+			host = hostOf(t.URL)
+		}
+		hosts = append(hosts, AllowlistHost{Host: host, Purpose: t.Purpose})
 	}
-
-	tenant := e.Tenant
-	if tenant == "" {
-		tenant = "<tenant>"
-	}
-	return append(hosts, AllowlistHost{
-		Host: fmt.Sprintf(constants.SBOMUploadHostPattern,
-			constants.DefaultUploadEnv, constants.DefaultS3Region, tenant, constants.DefaultS3Region),
-		Purpose: "SBOM artifact upload (AWS S3)",
-	})
+	return hosts
 }
 
 // Check probes every target concurrently and returns results in target order.

--- a/pkg/connectivity/connectivity_test.go
+++ b/pkg/connectivity/connectivity_test.go
@@ -1,0 +1,366 @@
+// Copyright (c) Kusari <https://www.kusari.dev/>
+// SPDX-License-Identifier: MIT
+
+package connectivity
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kusaridev/kusari-cli/v2/pkg/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// directProxy is a ProxyResolver that always reports "no proxy". Tests inject a
+// resolver rather than setting HTTPS_PROXY, because net/http caches the proxy
+// environment behind a sync.Once at the first proxy lookup, which would make
+// environment-mutating tests order-dependent.
+func directProxy(*http.Request) (*url.URL, error) { return nil, nil }
+
+func checkOne(t *testing.T, target Target, opts Options) Result {
+	t.Helper()
+	if opts.ProxyResolver == nil {
+		opts.ProxyResolver = directProxy
+	}
+	results := Check(context.Background(), []Target{target}, opts)
+	require.Len(t, results, 1)
+	return results[0]
+}
+
+// Any HTTP status means the network path works. This is the central pass rule:
+// the check is unauthenticated, so 401/403/404 are expected, and a 5xx is a
+// Kusari service problem rather than a user network problem.
+func TestCheckAnyStatusIsReachable(t *testing.T) {
+	for _, code := range []int{200, 204, 301, 400, 401, 403, 404, 405, 429, 500, 502, 503} {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(code)
+			}))
+			defer srv.Close()
+
+			res := checkOne(t, Target{Name: "t", URL: srv.URL}, Options{})
+
+			assert.True(t, res.OK(), "status %d must count as reachable", code)
+			assert.Equal(t, code, res.StatusCode)
+			assert.Equal(t, CategoryOK, res.Diag.Category)
+			assert.NoError(t, res.Err)
+			assert.Equal(t, code >= 500, res.ServiceError())
+		})
+	}
+}
+
+// Redirects must not be followed: doing so would report a status from a host we
+// never intended to probe and could mask a failure at the real endpoint.
+func TestCheckDoesNotFollowRedirects(t *testing.T) {
+	var reqs int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reqs++
+		w.Header().Set("Location", "https://aws.amazon.com/s3/")
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer srv.Close()
+
+	res := checkOne(t, Target{Name: "upload", URL: srv.URL}, Options{})
+
+	assert.True(t, res.OK())
+	assert.Equal(t, http.StatusTemporaryRedirect, res.StatusCode)
+	assert.Equal(t, "https://aws.amazon.com/s3/", res.Location)
+	assert.Equal(t, 1, reqs, "exactly one request; the redirect must not be followed")
+}
+
+func TestCheckTimeout(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-release
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	res := checkOne(t, Target{Name: "slow", URL: srv.URL}, Options{Timeout: 50 * time.Millisecond})
+
+	assert.False(t, res.OK())
+	assert.Equal(t, CategoryTimeout, res.Diag.Category)
+	assert.NotEmpty(t, res.Diag.Remediation)
+}
+
+func TestCheckConnectionRefused(t *testing.T) {
+	// Bind then immediately close, so the port is almost certainly free and
+	// nothing is listening.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+
+	res := checkOne(t, Target{Name: "dead", URL: "http://" + addr}, Options{})
+
+	assert.False(t, res.OK())
+	assert.Equal(t, CategoryTCP, res.Diag.Category)
+}
+
+// An httptest TLS server uses a self-signed cert that system roots do not
+// trust, which is exactly the shape of a TLS-inspecting corporate proxy.
+func TestCheckUntrustedTLS(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	res := checkOne(t, Target{Name: "tls", URL: srv.URL}, Options{})
+
+	assert.False(t, res.OK())
+	assert.Equal(t, CategoryTLSTrust, res.Diag.Category)
+	assert.Contains(t, strings.Join(res.Diag.Remediation, "\n"), "IGNORED on macOS")
+}
+
+func TestCheckCapturesTLSInfoOnSuccess(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Trust the test server's CA so the probe succeeds, then assert we still
+	// recorded who issued the certificate. Reporting the issuer on success is
+	// what tells an operator their traffic is being inspected.
+	target := Target{Name: "tls", URL: srv.URL}
+	client := &http.Client{Transport: srv.Client().Transport}
+	req, err := http.NewRequest(http.MethodGet, target.URL, nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.NotNil(t, resp.TLS)
+
+	info := tlsInfo(resp.TLS)
+	require.NotNil(t, info)
+	assert.True(t, strings.HasPrefix(info.Version, "TLS"), "got %q", info.Version)
+	assert.NotEmpty(t, info.CipherSuite)
+}
+
+func TestCheckInvalidProxyConfiguration(t *testing.T) {
+	res := checkOne(t, Target{Name: "t", URL: "https://example.invalid/"}, Options{
+		ProxyResolver: func(*http.Request) (*url.URL, error) {
+			return nil, &url.Error{Op: "parse", URL: "not a url", Err: assertErr{}}
+		},
+	})
+
+	assert.False(t, res.OK())
+	assert.Equal(t, CategoryProxy, res.Diag.Category)
+	assert.Contains(t, res.Diag.Summary, "invalid proxy configuration")
+}
+
+type assertErr struct{}
+
+func (assertErr) Error() string { return "bad proxy" }
+
+// Results must come back in target order regardless of which probe finishes
+// first, so the table is stable between runs.
+func TestCheckPreservesTargetOrder(t *testing.T) {
+	fast := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer fast.Close()
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(120 * time.Millisecond)
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	defer slow.Close()
+
+	targets := []Target{
+		{Name: "slow", URL: slow.URL},
+		{Name: "fast", URL: fast.URL},
+	}
+	results := Check(context.Background(), targets, Options{ProxyResolver: directProxy})
+
+	require.Len(t, results, 2)
+	assert.Equal(t, "slow", results[0].Target.Name)
+	assert.Equal(t, "fast", results[1].Target.Name)
+}
+
+func TestCheckReportsResolvedProxy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// A proxy URL carrying a password. The label must never leak it.
+	res := checkOne(t, Target{Name: "t", URL: srv.URL}, Options{
+		ProxyResolver: func(*http.Request) (*url.URL, error) {
+			return url.Parse("http://svc:s3cr3t@proxy.corp.example:8080")
+		},
+	})
+
+	require.NotNil(t, res.Proxy)
+	assert.Equal(t, "proxy.corp.example:8080", ProxyLabel(res.Proxy))
+	assert.NotContains(t, ProxyLabel(res.Proxy), "s3cr3t")
+	assert.NotContains(t, ProxySummary(res.Proxy), "s3cr3t")
+	assert.Contains(t, ProxySummary(res.Proxy), "xxxxx")
+}
+
+func TestProxyLabelAndSummaryHandleNil(t *testing.T) {
+	assert.Equal(t, "direct", ProxyLabel(nil))
+	assert.Empty(t, ProxySummary(nil))
+}
+
+func TestDefaultTargets(t *testing.T) {
+	// Deliberately omit trailing slashes: the naive concatenation used
+	// elsewhere in this repo would produce "...cloudoauth2/token".
+	targets := DefaultTargets(Endpoints{
+		AuthURL:     "https://auth.us.kusari.cloud",
+		PlatformURL: "https://platform.api.us.kusari.cloud",
+		ConsoleURL:  "https://console.us.kusari.cloud",
+		Tenant:      "acme",
+	})
+
+	require.Len(t, targets, 5)
+	assert.Equal(t, "auth", targets[0].Name)
+	assert.Equal(t, "https://auth.us.kusari.cloud/oauth2/token", targets[0].URL)
+	assert.Equal(t, "platform", targets[1].Name)
+	assert.Equal(t, "https://platform.api.us.kusari.cloud/user", targets[1].URL)
+	assert.Equal(t, "console", targets[2].Name)
+	assert.Equal(t, "https://console.us.kusari.cloud/", targets[2].URL)
+	assert.Equal(t, "upload-sbom", targets[3].Name)
+	assert.Equal(t, "https://kusari-guac-ingest-prod-us-east-1-acme.s3.us-east-1.amazonaws.com", targets[3].URL)
+	assert.Equal(t, "upload-scan", targets[4].Name)
+	assert.Equal(t, "https://inspector-bundle-upload-prod-us-east-1.s3.us-east-1.amazonaws.com", targets[4].URL)
+
+	// Trailing slashes present must produce the same URLs.
+	withSlashes := DefaultTargets(Endpoints{
+		AuthURL:     "https://auth.us.kusari.cloud/",
+		PlatformURL: "https://platform.api.us.kusari.cloud/",
+		ConsoleURL:  "https://console.us.kusari.cloud/",
+		Tenant:      "acme",
+	})
+	assert.Equal(t, targets, withSlashes)
+}
+
+// With no tenant the SBOM bucket hostname is unknowable, so it must be omitted
+// rather than guessed at -- a guessed hostname in the allowlist output would be
+// bad advice to hand a network team.
+func TestDefaultTargetsOmitsSBOMBucketWithoutTenant(t *testing.T) {
+	targets := DefaultTargets(Endpoints{
+		AuthURL:     constants.DefaultAuthURL,
+		PlatformURL: constants.DefaultPlatformURL,
+		ConsoleURL:  constants.DefaultConsoleURL,
+	})
+
+	require.Len(t, targets, 4)
+
+	var names []string
+	for _, tg := range targets {
+		names = append(names, tg.Name)
+	}
+	assert.Equal(t, []string{"auth", "platform", "console", "upload-scan"}, names)
+
+	for _, tg := range targets {
+		assert.NotContains(t, tg.URL, "guac-ingest", "no guessed bucket name")
+	}
+}
+
+func TestAllowlistHosts(t *testing.T) {
+	e := Endpoints{
+		AuthURL:     constants.DefaultAuthURL,
+		PlatformURL: constants.DefaultPlatformURL,
+		ConsoleURL:  constants.DefaultConsoleURL,
+		Tenant:      "acme",
+	}
+	hosts := AllowlistHosts(DefaultTargets(e))
+
+	require.Len(t, hosts, 5)
+	for _, h := range hosts {
+		assert.NotEmpty(t, h.Purpose)
+		assert.NotContains(t, h.Host, "/", "allowlist entries are hostnames, not URLs")
+	}
+	assert.Equal(t, "kusari-guac-ingest-prod-us-east-1-acme.s3.us-east-1.amazonaws.com", hosts[3].Host)
+	assert.Equal(t, "inspector-bundle-upload-prod-us-east-1.s3.us-east-1.amazonaws.com", hosts[4].Host)
+}
+
+func TestOptionsDefaults(t *testing.T) {
+	o := Options{}.withDefaults()
+	assert.Equal(t, DefaultTimeout, o.Timeout)
+	assert.NotNil(t, o.ProxyResolver)
+	assert.NotEmpty(t, o.UserAgent)
+
+	custom := Options{Timeout: time.Second, UserAgent: "x", ProxyResolver: directProxy}.withDefaults()
+	assert.Equal(t, time.Second, custom.Timeout)
+	assert.Equal(t, "x", custom.UserAgent)
+}
+
+// The probe transport must be a clone of http.DefaultTransport. Building one
+// from scratch would silently drop proxy support, HTTP/2 and every default
+// timeout, so the check would diagnose a stack the CLI never uses.
+func TestNewTransportInheritsDefaults(t *testing.T) {
+	def := http.DefaultTransport.(*http.Transport)
+	tr := newTransport()
+
+	assert.NotNil(t, tr.Proxy, "proxy support must be inherited from DefaultTransport")
+	assert.Equal(t, def.TLSHandshakeTimeout, tr.TLSHandshakeTimeout)
+	assert.Equal(t, def.ExpectContinueTimeout, tr.ExpectContinueTimeout)
+	assert.Equal(t, def.ForceAttemptHTTP2, tr.ForceAttemptHTTP2)
+	assert.NotNil(t, tr.OnProxyConnectResponse)
+	assert.True(t, tr.DisableKeepAlives, "each target needs a fresh DNS/TCP/TLS path")
+
+	// Clone() materializes a TLSClientConfig carrying NextProtos, so it is not
+	// nil. What matters is that verification stays on against system roots:
+	// there is no --insecure and no --ca-cert.
+	if tr.TLSClientConfig != nil {
+		assert.False(t, tr.TLSClientConfig.InsecureSkipVerify, "TLS verification must stay enabled")
+		assert.Nil(t, tr.TLSClientConfig.RootCAs, "must use system roots")
+	}
+}
+
+// A base URL carrying a query, fragment or userinfo must not leak into the
+// probe URL: it lands in the report, and appending the path after a query would
+// probe the wrong endpoint entirely.
+func TestJoinURLDropsQueryFragmentAndUserinfo(t *testing.T) {
+	cases := []struct {
+		base, path, want string
+	}{
+		{"https://h.example/", "user", "https://h.example/user"},
+		{"https://h.example", "user", "https://h.example/user"},
+		{"https://h.example", "/user", "https://h.example/user"},
+		{"https://h.example/api/", "user", "https://h.example/api/user"},
+		{"https://h.example/", "", "https://h.example/"},
+		{"https://h.example", "", "https://h.example/"},
+		// The leak and the wrong-path bug, in one input.
+		{"https://h.example/?apikey=SECRET", "user", "https://h.example/user"},
+		{"https://h.example/#frag", "user", "https://h.example/user"},
+		{"https://u:p@h.example/", "user", "https://h.example/user"},
+		{"https://h.example/?", "user", "https://h.example/user"},
+		{"  https://h.example/  ", "user", "https://h.example/user"},
+	}
+	for _, c := range cases {
+		got := joinURL(c.base, c.path)
+		assert.Equal(t, c.want, got, "joinURL(%q, %q)", c.base, c.path)
+		assert.NotContains(t, got, "SECRET")
+		assert.NotContains(t, got, "u:p@")
+	}
+}
+
+func TestDefaultTargetsSanitizesOverriddenBaseURLs(t *testing.T) {
+	targets := DefaultTargets(Endpoints{
+		AuthURL:     "https://auth.internal.example/?token=AUTHSECRET",
+		PlatformURL: "https://mirror.internal.example/?apikey=PLATSECRET",
+		ConsoleURL:  "https://console.internal.example/?sso=CONSOLESECRET",
+	})
+
+	require.NotEmpty(t, targets)
+	for _, tg := range targets {
+		assert.NotContains(t, tg.URL, "SECRET", "target %s leaked a query secret", tg.Name)
+	}
+	assert.Equal(t, "https://auth.internal.example/oauth2/token", targets[0].URL)
+	assert.Equal(t, "https://mirror.internal.example/user", targets[1].URL)
+	assert.Equal(t, "https://console.internal.example/", targets[2].URL)
+}
+
+func TestHostOf(t *testing.T) {
+	assert.Equal(t, "platform.api.us.kusari.cloud", hostOf("https://platform.api.us.kusari.cloud/user"))
+	assert.Equal(t, "example.com", hostOf("https://example.com:8443/x"))
+	assert.Equal(t, "not a url", hostOf("not a url"))
+}

--- a/pkg/connectivity/connectivity_test.go
+++ b/pkg/connectivity/connectivity_test.go
@@ -218,17 +218,22 @@ func TestDefaultTargets(t *testing.T) {
 		Tenant:      "acme",
 	})
 
-	require.Len(t, targets, 5)
+	require.Len(t, targets, 4)
 	assert.Equal(t, "auth", targets[0].Name)
 	assert.Equal(t, "https://auth.us.kusari.cloud/oauth2/token", targets[0].URL)
 	assert.Equal(t, "platform", targets[1].Name)
 	assert.Equal(t, "https://platform.api.us.kusari.cloud/user", targets[1].URL)
 	assert.Equal(t, "console", targets[2].Name)
 	assert.Equal(t, "https://console.us.kusari.cloud/", targets[2].URL)
-	assert.Equal(t, "upload-sbom", targets[3].Name)
-	assert.Equal(t, "https://kusari-guac-ingest-prod-us-east-1-acme.s3.us-east-1.amazonaws.com", targets[3].URL)
-	assert.Equal(t, "upload-scan", targets[4].Name)
-	assert.Equal(t, "https://inspector-bundle-upload-prod-us-east-1.s3.us-east-1.amazonaws.com", targets[4].URL)
+	assert.Equal(t, "upload", targets[3].Name)
+	assert.Equal(t, "https://inspector-bundle-upload-prod-us-east-1.s3.us-east-1.amazonaws.com", targets[3].URL)
+
+	// One S3 probe is representative (wildcard DNS, shared certificate), so the
+	// tenant-derived SBOM bucket must never be probed.
+	for _, tg := range targets {
+		assert.NotContains(t, tg.URL, "guac-ingest")
+		assert.NotContains(t, tg.URL, "acme")
+	}
 
 	// Trailing slashes present must produce the same URLs.
 	withSlashes := DefaultTargets(Endpoints{
@@ -240,29 +245,6 @@ func TestDefaultTargets(t *testing.T) {
 	assert.Equal(t, targets, withSlashes)
 }
 
-// With no tenant the SBOM bucket hostname is unknowable, so it must be omitted
-// rather than guessed at -- a guessed hostname in the allowlist output would be
-// bad advice to hand a network team.
-func TestDefaultTargetsOmitsSBOMBucketWithoutTenant(t *testing.T) {
-	targets := DefaultTargets(Endpoints{
-		AuthURL:     constants.DefaultAuthURL,
-		PlatformURL: constants.DefaultPlatformURL,
-		ConsoleURL:  constants.DefaultConsoleURL,
-	})
-
-	require.Len(t, targets, 4)
-
-	var names []string
-	for _, tg := range targets {
-		names = append(names, tg.Name)
-	}
-	assert.Equal(t, []string{"auth", "platform", "console", "upload-scan"}, names)
-
-	for _, tg := range targets {
-		assert.NotContains(t, tg.URL, "guac-ingest", "no guessed bucket name")
-	}
-}
-
 func TestAllowlistHosts(t *testing.T) {
 	e := Endpoints{
 		AuthURL:     constants.DefaultAuthURL,
@@ -270,15 +252,29 @@ func TestAllowlistHosts(t *testing.T) {
 		ConsoleURL:  constants.DefaultConsoleURL,
 		Tenant:      "acme",
 	}
-	hosts := AllowlistHosts(DefaultTargets(e))
+	hosts := AllowlistHosts(e, DefaultTargets(e))
 
 	require.Len(t, hosts, 5)
 	for _, h := range hosts {
 		assert.NotEmpty(t, h.Purpose)
 		assert.NotContains(t, h.Host, "/", "allowlist entries are hostnames, not URLs")
 	}
-	assert.Equal(t, "kusari-guac-ingest-prod-us-east-1-acme.s3.us-east-1.amazonaws.com", hosts[3].Host)
-	assert.Equal(t, "inspector-bundle-upload-prod-us-east-1.s3.us-east-1.amazonaws.com", hosts[4].Host)
+	assert.Equal(t, "inspector-bundle-upload-prod-us-east-1.s3.us-east-1.amazonaws.com", hosts[3].Host)
+	assert.Equal(t, "kusari-guac-ingest-prod-us-east-1-acme.s3.us-east-1.amazonaws.com", hosts[4].Host)
+}
+
+// Without a tenant the allowlist still shows the SBOM bucket, with an explicit
+// placeholder rather than a guessed hostname.
+func TestAllowlistHostsUsesPlaceholderWithoutTenant(t *testing.T) {
+	e := Endpoints{
+		AuthURL:     constants.DefaultAuthURL,
+		PlatformURL: constants.DefaultPlatformURL,
+		ConsoleURL:  constants.DefaultConsoleURL,
+	}
+	hosts := AllowlistHosts(e, DefaultTargets(e))
+
+	require.Len(t, hosts, 5)
+	assert.Equal(t, "kusari-guac-ingest-prod-us-east-1-<tenant>.s3.us-east-1.amazonaws.com", hosts[4].Host)
 }
 
 func TestOptionsDefaults(t *testing.T) {

--- a/pkg/connectivity/connectivity_test.go
+++ b/pkg/connectivity/connectivity_test.go
@@ -215,7 +215,6 @@ func TestDefaultTargets(t *testing.T) {
 		AuthURL:     "https://auth.us.kusari.cloud",
 		PlatformURL: "https://platform.api.us.kusari.cloud",
 		ConsoleURL:  "https://console.us.kusari.cloud",
-		Tenant:      "acme",
 	})
 
 	require.Len(t, targets, 4)
@@ -228,11 +227,10 @@ func TestDefaultTargets(t *testing.T) {
 	assert.Equal(t, "upload", targets[3].Name)
 	assert.Equal(t, "https://inspector-bundle-upload-prod-us-east-1.s3.us-east-1.amazonaws.com", targets[3].URL)
 
-	// One S3 probe is representative (wildcard DNS, shared certificate), so the
-	// tenant-derived SBOM bucket must never be probed.
+	// One S3 probe is representative (wildcard DNS, shared certificate); no
+	// tenant-derived hostname may ever be built or probed.
 	for _, tg := range targets {
 		assert.NotContains(t, tg.URL, "guac-ingest")
-		assert.NotContains(t, tg.URL, "acme")
 	}
 
 	// Trailing slashes present must produce the same URLs.
@@ -240,7 +238,6 @@ func TestDefaultTargets(t *testing.T) {
 		AuthURL:     "https://auth.us.kusari.cloud/",
 		PlatformURL: "https://platform.api.us.kusari.cloud/",
 		ConsoleURL:  "https://console.us.kusari.cloud/",
-		Tenant:      "acme",
 	})
 	assert.Equal(t, targets, withSlashes)
 }
@@ -250,31 +247,17 @@ func TestAllowlistHosts(t *testing.T) {
 		AuthURL:     constants.DefaultAuthURL,
 		PlatformURL: constants.DefaultPlatformURL,
 		ConsoleURL:  constants.DefaultConsoleURL,
-		Tenant:      "acme",
 	}
-	hosts := AllowlistHosts(e, DefaultTargets(e))
+	hosts := AllowlistHosts(DefaultTargets(e))
 
-	require.Len(t, hosts, 5)
+	require.Len(t, hosts, 4)
 	for _, h := range hosts {
 		assert.NotEmpty(t, h.Purpose)
 		assert.NotContains(t, h.Host, "/", "allowlist entries are hostnames, not URLs")
 	}
-	assert.Equal(t, "inspector-bundle-upload-prod-us-east-1.s3.us-east-1.amazonaws.com", hosts[3].Host)
-	assert.Equal(t, "kusari-guac-ingest-prod-us-east-1-acme.s3.us-east-1.amazonaws.com", hosts[4].Host)
-}
-
-// Without a tenant the allowlist still shows the SBOM bucket, with an explicit
-// placeholder rather than a guessed hostname.
-func TestAllowlistHostsUsesPlaceholderWithoutTenant(t *testing.T) {
-	e := Endpoints{
-		AuthURL:     constants.DefaultAuthURL,
-		PlatformURL: constants.DefaultPlatformURL,
-		ConsoleURL:  constants.DefaultConsoleURL,
-	}
-	hosts := AllowlistHosts(e, DefaultTargets(e))
-
-	require.Len(t, hosts, 5)
-	assert.Equal(t, "kusari-guac-ingest-prod-us-east-1-<tenant>.s3.us-east-1.amazonaws.com", hosts[4].Host)
+	// The upload entry is the S3 wildcard, covering every bucket -- including
+	// tenant-specific ones -- without naming any of them.
+	assert.Equal(t, "*.s3.us-east-1.amazonaws.com", hosts[3].Host)
 }
 
 func TestOptionsDefaults(t *testing.T) {

--- a/pkg/connectivity/report.go
+++ b/pkg/connectivity/report.go
@@ -1,0 +1,189 @@
+// Copyright (c) Kusari <https://www.kusari.dev/>
+// SPDX-License-Identifier: MIT
+
+package connectivity
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Report is the machine-readable result for a support ticket. The shape mirrors
+// iac/app-code/preflight/kusari-preflight-test.sh, plus the failure category.
+//
+// It is written expecting to leave the machine, so it discloses as little about
+// the environment as the diagnostics allow: no hostname, no proxy credentials or
+// usernames, and no NO_PROXY contents. This command loads no tokens, so there is
+// no auth material to leak either.
+type Report struct {
+	SystemInfo SystemInfo      `json:"systemInfo"`
+	Tests      []TestResult    `json:"tests"`
+	Allowlist  []AllowlistHost `json:"allowlist"`
+	Summary    Summary         `json:"summary"`
+}
+
+// SystemInfo deliberately omits the hostname: corporate asset names commonly
+// encode a person, department or site, and os/arch already cover the
+// platform-specific diagnostics.
+type SystemInfo struct {
+	OS         string      `json:"os"`
+	Arch       string      `json:"arch"`
+	CLIVersion string      `json:"cliVersion"`
+	Timestamp  string      `json:"timestamp"`
+	Proxy      ProxyConfig `json:"proxy"`
+}
+
+// ProxyConfig records the proxy environment with passwords redacted. Use
+// forReport before serializing.
+type ProxyConfig struct {
+	HTTP    string `json:"http"`
+	HTTPS   string `json:"https"`
+	NoProxy string `json:"noProxy"`
+}
+
+// forReport strips what the terminal may show but a shared file should not: the
+// proxy userinfo (a service-account name is useful for spraying and phishing)
+// and the NO_PROXY contents, which are an inventory of internal domains, CIDRs
+// and hostnames. No diagnostic value is lost -- a per-target proxy of "direct"
+// already identifies which endpoints NO_PROXY matched.
+func (p ProxyConfig) forReport() ProxyConfig {
+	return ProxyConfig{
+		HTTP:    stripUserinfo(p.HTTP),
+		HTTPS:   stripUserinfo(p.HTTPS),
+		NoProxy: summarizeNoProxy(p.NoProxy),
+	}
+}
+
+func stripUserinfo(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return "(set, unparseable)"
+	}
+	u.User = nil
+	return u.String()
+}
+
+func summarizeNoProxy(raw string) string {
+	n := 0
+	for _, e := range strings.Split(raw, ",") {
+		if strings.TrimSpace(e) != "" {
+			n++
+		}
+	}
+	if n == 0 {
+		return ""
+	}
+	return fmt.Sprintf("(set, %d entries)", n)
+}
+
+type TestResult struct {
+	Name          string   `json:"name"`
+	Purpose       string   `json:"purpose"`
+	URL           string   `json:"url"`
+	Status        string   `json:"status"`
+	StatusCode    int      `json:"statusCode,omitempty"`
+	LatencyMs     int64    `json:"latencyMs"`
+	Category      Category `json:"category"`
+	Proxy         string   `json:"proxy,omitempty"`
+	Authenticated bool     `json:"authenticated"`
+	Error         string   `json:"error,omitempty"`
+	TLS           *TLSInfo `json:"tls,omitempty"`
+}
+
+type Summary struct {
+	Total  int `json:"total"`
+	Passed int `json:"passed"`
+	Failed int `json:"failed"`
+}
+
+// BuildReport assembles a Report; now is injected so callers control the stamp.
+func BuildReport(results []Result, allowlist []AllowlistHost, cliVersion string, proxyEnv ProxyConfig, now time.Time) Report {
+	rep := Report{
+		SystemInfo: SystemInfo{
+			OS:         runtime.GOOS,
+			Arch:       runtime.GOARCH,
+			CLIVersion: cliVersion,
+			Timestamp:  now.UTC().Format(time.RFC3339),
+			Proxy:      proxyEnv.forReport(),
+		},
+		Tests:     make([]TestResult, 0, len(results)),
+		Allowlist: allowlist,
+	}
+
+	for _, r := range results {
+		tr := TestResult{
+			Name:       r.Target.Name,
+			Purpose:    r.Target.Purpose,
+			URL:        r.Target.URL,
+			StatusCode: r.StatusCode,
+			LatencyMs:  r.Duration.Milliseconds(),
+			Category:   r.Diag.Category,
+			Proxy:      ProxyLabel(r.Proxy),
+			TLS:        r.TLS,
+		}
+		if r.OK() {
+			tr.Status = "pass"
+			rep.Summary.Passed++
+		} else {
+			tr.Status = "fail"
+			tr.Error = r.Diag.Summary
+			rep.Summary.Failed++
+		}
+		rep.Tests = append(rep.Tests, tr)
+	}
+	rep.Summary.Total = len(results)
+
+	return rep
+}
+
+// WriteReport writes rep to path as indented JSON with owner-only permissions.
+func WriteReport(path string, rep Report) error {
+	data, err := json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to encode report: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("failed to write report to %s: %w", path, err)
+	}
+	return nil
+}
+
+// ProxyEnvConfig reads the proxy environment, redacted. lookup is os.Getenv.
+func ProxyEnvConfig(lookup func(string) string) ProxyConfig {
+	return ProxyConfig{
+		HTTP:    redactEnvProxy(firstEnv(lookup, "HTTP_PROXY", "http_proxy")),
+		HTTPS:   redactEnvProxy(firstEnv(lookup, "HTTPS_PROXY", "https_proxy")),
+		NoProxy: firstEnv(lookup, "NO_PROXY", "no_proxy"),
+	}
+}
+
+func firstEnv(lookup func(string) string, names ...string) string {
+	for _, n := range names {
+		if v := lookup(n); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// redactEnvProxy hides any password. An unparseable value is replaced rather
+// than echoed, since it may still contain credentials.
+func redactEnvProxy(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return "(set, unparseable)"
+	}
+	return u.Redacted()
+}

--- a/pkg/connectivity/report.go
+++ b/pkg/connectivity/report.go
@@ -13,8 +13,7 @@ import (
 	"time"
 )
 
-// Report is the machine-readable result for a support ticket. The shape mirrors
-// iac/app-code/preflight/kusari-preflight-test.sh, plus the failure category.
+// Report is the machine-readable result for a support ticket.
 //
 // It is written expecting to leave the machine, so it discloses as little about
 // the environment as the diagnostics allow: no hostname, no proxy credentials or

--- a/pkg/connectivity/report_test.go
+++ b/pkg/connectivity/report_test.go
@@ -1,0 +1,233 @@
+// Copyright (c) Kusari <https://www.kusari.dev/>
+// SPDX-License-Identifier: MIT
+
+package connectivity
+
+import (
+	"encoding/json"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func fixedTime() time.Time {
+	return time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+}
+
+func sampleResults(t *testing.T) []Result {
+	t.Helper()
+	proxy, err := url.Parse("http://svc:s3cr3t@proxy.corp.example:8080")
+	require.NoError(t, err)
+
+	return []Result{
+		{
+			Target:     Target{Name: "platform", Purpose: "Platform API", URL: "https://platform.api.us.kusari.cloud/user"},
+			Proxy:      proxy,
+			StatusCode: 401,
+			Status:     "401 Unauthorized",
+			Duration:   266 * time.Millisecond,
+			TLS:        &TLSInfo{Version: "TLS 1.3", CipherSuite: "TLS_AES_128_GCM_SHA256"},
+			Diag:       Diagnosis{Category: CategoryOK},
+		},
+		{
+			Target:   Target{Name: "auth", Purpose: "Authentication service (OAuth2)", URL: "https://auth.us.kusari.cloud/oauth2/token"},
+			Proxy:    proxy,
+			Duration: 1204 * time.Millisecond,
+			Diag: Diagnosis{
+				Category: CategoryTLSTrust,
+				Summary:  "TLS certificate not trusted",
+				Raw:      "x509: certificate signed by unknown authority",
+			},
+			Err: assertErr{},
+		},
+	}
+}
+
+func TestBuildReport(t *testing.T) {
+	results := sampleResults(t)
+	allowlist := []AllowlistHost{{Host: "h", Purpose: "p"}}
+	proxyEnv := ProxyConfig{HTTPS: "http://svc:xxxxx@proxy.corp.example:8080", NoProxy: "localhost"}
+
+	rep := BuildReport(results, allowlist, "v2.1.0", proxyEnv, fixedTime())
+
+	assert.Equal(t, "v2.1.0", rep.SystemInfo.CLIVersion)
+	assert.Equal(t, "2026-08-04T12:00:00Z", rep.SystemInfo.Timestamp)
+	assert.NotEmpty(t, rep.SystemInfo.OS)
+	assert.NotEmpty(t, rep.SystemInfo.Arch)
+	assert.Equal(t, allowlist, rep.Allowlist)
+
+	// BuildReport must redact on the way in, so a caller cannot serialize the
+	// raw environment by accident.
+	assert.Equal(t, "http://proxy.corp.example:8080", rep.SystemInfo.Proxy.HTTPS)
+	assert.Equal(t, "(set, 1 entries)", rep.SystemInfo.Proxy.NoProxy)
+
+	assert.Equal(t, Summary{Total: 2, Passed: 1, Failed: 1}, rep.Summary)
+
+	require.Len(t, rep.Tests, 2)
+	assert.Equal(t, "pass", rep.Tests[0].Status)
+	assert.Equal(t, 401, rep.Tests[0].StatusCode)
+	assert.Equal(t, int64(266), rep.Tests[0].LatencyMs)
+	assert.Equal(t, CategoryOK, rep.Tests[0].Category)
+	assert.Empty(t, rep.Tests[0].Error)
+	assert.False(t, rep.Tests[0].Authenticated, "this command never authenticates")
+
+	assert.Equal(t, "fail", rep.Tests[1].Status)
+	assert.Equal(t, CategoryTLSTrust, rep.Tests[1].Category)
+	assert.Equal(t, "TLS certificate not trusted", rep.Tests[1].Error)
+}
+
+// The report is written expecting to leave the machine, so it must disclose no
+// credentials, no service-account name, no hostname, and no internal network
+// inventory. Everything asserted absent here is real-world sensitive: a proxy
+// service account is a spraying/phishing target, an asset hostname commonly
+// encodes a person or department, and NO_PROXY is an inventory of internal
+// domains, CIDRs and hosts.
+func TestReportDisclosesNoEnvironmentDetail(t *testing.T) {
+	// The NO_PROXY domain suffix is deliberately NOT a substring of the proxy
+	// hostname, which is retained; otherwise the assertions below contradict
+	// each other.
+	env := map[string]string{
+		"HTTPS_PROXY": "http://svc-kusari:s3cr3t@proxy.emea.corp.example.com:8080",
+		"NO_PROXY": "localhost,.intranet.example.net,10.0.0.0/8," +
+			"vault.prod.internal,sap-prod-db01.fin.internal",
+	}
+	proxyEnv := ProxyEnvConfig(func(k string) string { return env[k] })
+
+	rep := BuildReport(sampleResults(t), nil, "v2.1.0", proxyEnv, fixedTime())
+	data, err := json.Marshal(rep)
+	require.NoError(t, err)
+	out := string(data)
+
+	for _, secret := range []string{
+		"s3cr3t",                     // password
+		"svc-kusari",                 // service-account name
+		"vault.prod.internal",        // internal hostname
+		"sap-prod-db01.fin.internal", // internal hostname
+		"10.0.0.0/8",                 // internal CIDR
+		".intranet.example.net",      // internal domain suffix
+	} {
+		assert.NotContains(t, out, secret)
+	}
+
+	if hostname, err := os.Hostname(); err == nil && hostname != "" {
+		assert.NotContains(t, out, hostname, "the report must not carry the machine hostname")
+	}
+
+	// The proxy host:port is kept -- it is the diagnostic -- and NO_PROXY is
+	// reduced to the fact that it is set.
+	assert.Contains(t, out, "proxy.emea.corp.example.com:8080")
+	assert.Contains(t, out, "(set, 5 entries)")
+}
+
+func TestProxyConfigForReport(t *testing.T) {
+	cases := []struct {
+		name string
+		in   ProxyConfig
+		want ProxyConfig
+	}{
+		{"empty stays empty", ProxyConfig{}, ProxyConfig{}},
+		{
+			"userinfo stripped entirely, not just the password",
+			ProxyConfig{HTTPS: "http://svc:xxxxx@h:8080"},
+			ProxyConfig{HTTPS: "http://h:8080"},
+		},
+		{
+			"host-only proxy is untouched",
+			ProxyConfig{HTTP: "http://h:8080"},
+			ProxyConfig{HTTP: "http://h:8080"},
+		},
+		{
+			"no_proxy reduced to a count",
+			ProxyConfig{NoProxy: "localhost, .corp.example, 10.0.0.0/8"},
+			ProxyConfig{NoProxy: "(set, 3 entries)"},
+		},
+		{"no_proxy of only separators counts as unset", ProxyConfig{NoProxy: " , , "}, ProxyConfig{}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, c.in.forReport())
+		})
+	}
+}
+
+func TestWriteReportRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "report.json")
+	want := BuildReport(sampleResults(t), []AllowlistHost{{Host: "h", Purpose: "p"}},
+		"v2.1.0", ProxyConfig{}, fixedTime())
+
+	require.NoError(t, WriteReport(path, want))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var got Report
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, want, got)
+}
+
+func TestWriteReportRejectsBadPath(t *testing.T) {
+	err := WriteReport(filepath.Join(t.TempDir(), "missing-dir", "r.json"), Report{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write report")
+}
+
+func TestProxyEnvConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want ProxyConfig
+	}{
+		{
+			name: "unset",
+			env:  map[string]string{},
+			want: ProxyConfig{},
+		},
+		{
+			name: "uppercase wins over lowercase",
+			env: map[string]string{
+				"HTTPS_PROXY": "http://upper:8080",
+				"https_proxy": "http://lower:8080",
+			},
+			want: ProxyConfig{HTTPS: "http://upper:8080"},
+		},
+		{
+			name: "lowercase used when uppercase unset",
+			env:  map[string]string{"https_proxy": "http://lower:8080"},
+			want: ProxyConfig{HTTPS: "http://lower:8080"},
+		},
+		{
+			name: "password redacted",
+			env:  map[string]string{"HTTP_PROXY": "http://u:p@h:8080"},
+			want: ProxyConfig{HTTP: "http://u:xxxxx@h:8080"},
+		},
+		{
+			// An unparseable value may still contain credentials, so we must not
+			// echo it back verbatim.
+			name: "unparseable value is not echoed",
+			env:  map[string]string{"HTTPS_PROXY": "::not a url::"},
+			want: ProxyConfig{HTTPS: "(set, unparseable)"},
+		},
+		{
+			name: "no_proxy passes through",
+			env:  map[string]string{"NO_PROXY": "localhost,.corp.example"},
+			want: ProxyConfig{NoProxy: "localhost,.corp.example"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ProxyEnvConfig(func(k string) string { return c.env[k] })
+			assert.Equal(t, c.want, got)
+		})
+	}
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -9,4 +9,29 @@ const (
 
 	// DefaultConsoleURL is the default Kusari console URL
 	DefaultConsoleURL = "https://console.us.kusari.cloud/"
+
+	// DefaultAuthURL is the default Kusari authentication endpoint URL
+	DefaultAuthURL = "https://auth.us.kusari.cloud/"
+)
+
+// Upload bucket hostnames, used only by `kusari connectivity check`.
+//
+// Uploads never derive a URL from these: the real host is issued per-request by
+// the platform presign response (pkg/repo/upload.go). They are a second source
+// of truth, so update them if platform bucket naming changes.
+//
+// Source: iac/app-code/preflight/kusari-preflight-test.sh
+const (
+	// SBOMUploadHostPattern takes env, s3 region, tenant, s3 region.
+	SBOMUploadHostPattern = "kusari-guac-ingest-%s-%s-%s.s3.%s.amazonaws.com"
+
+	// InspectorUploadHostPattern takes env, s3 region, s3 region.
+	InspectorUploadHostPattern = "inspector-bundle-upload-%s-%s.s3.%s.amazonaws.com"
+
+	DefaultUploadEnv = "prod"
+
+	// DefaultS3Region: non-us regions need a real mapping here, not string
+	// interpolation. The preflight script's "${REGION}-east-1" yields the
+	// nonexistent "eu-east-1".
+	DefaultS3Region = "us-east-1"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -19,8 +19,6 @@ const (
 // Uploads never derive a URL from these: the real host is issued per-request by
 // the platform presign response (pkg/repo/upload.go). They are a second source
 // of truth, so update them if platform bucket naming changes.
-//
-// Source: iac/app-code/preflight/kusari-preflight-test.sh
 const (
 	// SBOMUploadHostPattern takes env, s3 region, tenant, s3 region.
 	SBOMUploadHostPattern = "kusari-guac-ingest-%s-%s-%s.s3.%s.amazonaws.com"
@@ -30,8 +28,7 @@ const (
 
 	DefaultUploadEnv = "prod"
 
-	// DefaultS3Region: non-us regions need a real mapping here, not string
-	// interpolation. The preflight script's "${REGION}-east-1" yields the
-	// nonexistent "eu-east-1".
+	// DefaultS3Region: non-us Kusari regions need a real region mapping here,
+	// not string interpolation from the region name.
 	DefaultS3Region = "us-east-1"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -14,15 +14,12 @@ const (
 	DefaultAuthURL = "https://auth.us.kusari.cloud/"
 )
 
-// Upload bucket hostnames, used only by `kusari connectivity check`.
+// Upload endpoint constants, used only by `kusari connectivity check`.
 //
 // Uploads never derive a URL from these: the real host is issued per-request by
 // the platform presign response (pkg/repo/upload.go). They are a second source
 // of truth, so update them if platform bucket naming changes.
 const (
-	// SBOMUploadHostPattern takes env, s3 region, tenant, s3 region.
-	SBOMUploadHostPattern = "kusari-guac-ingest-%s-%s-%s.s3.%s.amazonaws.com"
-
 	// InspectorUploadHostPattern takes env, s3 region, s3 region.
 	InspectorUploadHostPattern = "inspector-bundle-upload-%s-%s.s3.%s.amazonaws.com"
 


### PR DESCRIPTION
New command (aliases: conn, net, preflight) that probes the endpoints the CLI needs — auth, platform API, console, and the S3 upload buckets — and classifies failures (dns, tcp, tls-trust, proxy, timeout) with actionable remediation for corporate proxy/firewall environments.

- Proxy config comes only from HTTP_PROXY/HTTPS_PROXY/NO_PROXY via http.ProxyFromEnvironment, matching every other client in this CLI; no --proxy flag so a passing check reflects real CLI behavior.
- Transport is a Clone() of http.DefaultTransport; CONNECT responses are observed so a proxy 407/403 is reported with its real status.
- Pass rule: any HTTP status = reachable (401/403/404/5xx included); only DNS/TCP/TLS/proxy failures fail the check (exit 1).
- TLS trust failures name the interception CA issuer and give OS-specific fixes; deliberately no --insecure or --ca-cert.
- --report writes a support-ticket JSON that discloses no hostname, proxy userinfo, or NO_PROXY contents.
- Tenant SBOM bucket is probed only when a tenant is resolvable (tenant-endpoint > tenant > workspace.json), never guessed.
- Reads the auth-endpoint/tenant viper keys without re-binding them, avoiding clobbering the auth login / platform flag bindings.

Also dedupes the auth URL default into constants.DefaultAuthURL (was repeated in auth_login.go and pkg/ai/auth.go).

Known limitation: S3 bucket name patterns assume the us region / us-east-1, like the rest of the CLI's baked-in defaults.